### PR TITLE
Website overhaul howto

### DIFF
--- a/doc/add_openrsp_to_host_program.rst
+++ b/doc/add_openrsp_to_host_program.rst
@@ -1,0 +1,6 @@
+.. _chapter_add_openrsp_to_host_program:
+
+Add OpenRSP to a quantum chemistry program
+==========================================
+
+Add list of papers

--- a/doc/add_openrsp_to_host_program.rst
+++ b/doc/add_openrsp_to_host_program.rst
@@ -3,4 +3,17 @@
 Add OpenRSP to a quantum chemistry program
 ==========================================
 
-Add list of papers
+If you want to add OpenRSP to a quantum chemistry program, then you are free to do so provided
+that you do not violate OpenRSP's LGPL v2.1 software license as described on OpenRSP's 
+`GitHub repository <https://github.com/openrsp/openrsp>`_.
+
+In order to enable OpenRSP to work as intended, you must provide routines that connect to the
+OpenRSP application programming interface (API) to give OpenRSP access to contributions such as
+perturbed one- and two electron integrals, exchange-correlation contributions if calculations at
+the density-functional theory (DFT) level is desired, or solution routines for response equations.
+Please note that OpenRSP is a program library that manages the calculation of response properties,
+and it **cannot** calculate these properties without getting contributions like the ones
+mentioned here from program routines that are external to OpenRSP.
+
+A description of the API is under development and will be made available on this website.
+In the meantime, questions may be directed to the :ref:`chapter_authors`.

--- a/doc/add_openrsp_to_host_program.rst
+++ b/doc/add_openrsp_to_host_program.rst
@@ -12,7 +12,7 @@ OpenRSP application programming interface (API) to give OpenRSP access to contri
 perturbed one- and two electron integrals, exchange-correlation contributions if calculations at
 the density-functional theory (DFT) level is desired, or solution routines for response equations.
 Please note that OpenRSP is a program library that manages the calculation of response properties,
-and it **cannot** calculate these properties without getting contributions like the ones
+and it **cannot** carry out this task without getting contributions like the ones
 mentioned here from program routines that are external to OpenRSP.
 
 A description of the API is under development and will be made available on this website.

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -26,4 +26,5 @@ This table lists the main developers of OpenRSP and their current affiliation:
    * - Andreas J. Thorvaldsen
      - Science [&] Technology AS
 
-Requests or comments should primarily be directed to authors listed in **boldface**.
+Requests or comments should primarily be directed to authors listed in **boldface** whose e-mail
+addresses are all in the format *firstname.lastname@uit.no*.

--- a/doc/authors.rst
+++ b/doc/authors.rst
@@ -11,17 +11,19 @@ This table lists the main developers of OpenRSP and their current affiliation:
 
    * - Name
      - Affiliation
-   * - Radovan Bast
+   * - **Radovan Bast**
      - UiT The Arctic University of Norway
    * - Daniel H. Friese
      - Heinrich-Heine-Universität Düsseldorf
-   * - Bin Gao
+   * - **Bin Gao**
      - UiT The Arctic University of Norway
    * - Dan J. Jonsson
      - UiT The Arctic University of Norway
-   * - Magnus Ringholm
+   * - **Magnus Ringholm**
      - UiT The Arctic University of Norway
    * - Kenneth Ruud
      - UiT The Arctic University of Norway
    * - Andreas J. Thorvaldsen
      - Science [&] Technology AS
+
+Requests or comments should primarily be directed to authors listed in **boldface**.

--- a/doc/get_involved_development.rst
+++ b/doc/get_involved_development.rst
@@ -1,6 +1,20 @@
-.. _chapter_theoretical_background:
+.. _chapter_get_involved_development:
 
 Get involved with development
 =============================
 
-Add list of papers
+We welcome your participation if you want to become involved with the development of OpenRSP!
+Our code is `hosted on GitHub <https://github.com/openrsp/openrsp>`_ and is publicly available
+under the LGPL v2.1 software license. You may freely obtain and use this code provided that
+you do not violate this software license, but us present :ref:`chapter_authors` would of course
+would of course also like to get in touch with you.
+
+We are still working on a documentation of the OpenRSP code and API, and this will be made 
+available on this website when ready.
+
+
+
+
+
+
+

--- a/doc/get_involved_development.rst
+++ b/doc/get_involved_development.rst
@@ -10,7 +10,8 @@ you do not violate this software license, but us present :ref:`chapter_authors` 
 would of course also like to get in touch with you.
 
 We are still working on a documentation of the OpenRSP code and API, and this will be made 
-available on this website when ready.
+available on this website when ready. A style guide and contribution guidelines are also under
+development.
 
 
 

--- a/doc/get_involved_development.rst
+++ b/doc/get_involved_development.rst
@@ -1,0 +1,6 @@
+.. _chapter_theoretical_background:
+
+Get involved with development
+=============================
+
+Add list of papers

--- a/doc/getting_running_openrsp.rst
+++ b/doc/getting_running_openrsp.rst
@@ -7,12 +7,15 @@ If you want to get OpenRSP and use it for calculations, then please make note of
 OpenRSP is a program library that manages the calculation of response properties, and it 
 **cannot** calculate these properties without getting contributions like perturbed one- and
 two-electron integrals or solutions of response equations from other codes to which it connects
-through the application programming interface (API). Such a set of API connections can be made
-in quantum chemistry programs the where necessary routines for these contributions are implemented.
+through the application programming interface (API). This means that if you download and build 
+OpenRSP from its `GitHub repository <https://github.com/openrsp/openrsp>`_, the compiled product 
+will not on its own be able to calculate response properties.
 
-Therefore, in order to use OpenRSP for calculations, it is necessary to use a *host program* into
-which OpenRSP has been incorporated in this way, and a list of such programs is kept at the
+A set of API connections to enable OpenRSP to manage response property calculation can be made
+in quantum chemistry programs the where necessary routines for these contributions are implemented.
+Therefore, in order to use OpenRSP for calculations, it is necessary to use such a *host program* 
+into which OpenRSP has been incorporated in this way, and a list of such programs is kept at the
 :ref:`chapter_programs_with_openrsp` page. The specific way in which OpenRSP is invoked in a host
-program - i.e. the way that you can make OpenRSP calculate something - is a feature of each such
-program, and you must therefore follow the relevant instructions to achieve this, for example as
-may be shown in the user manual, for the host program that you want to use.
+program - i.e. the way that you can make OpenRSP calculate something in that program - is a feature
+of each such program, and you must therefore follow the relevant instructions to achieve this, 
+as may for example be shown in the user manual, for the host program that you want to use.

--- a/doc/getting_running_openrsp.rst
+++ b/doc/getting_running_openrsp.rst
@@ -3,6 +3,16 @@
 Get and run OpenRSP
 ===================
 
-If you want to get OpenRSP and use it for calculations, then please make note of the following: OpenRSP is a program library that manages the calculation of response properties, and it **cannot** calculate these properties without getting contributions like perturbed one- and two-electron integrals or solutions of response equations from other codes to which it connects through the application programming interface (API). Such a set of API connections can be made in quantum chemistry programs the where necessary routines for these contributions are implemented.
+If you want to get OpenRSP and use it for calculations, then please make note of the following:
+OpenRSP is a program library that manages the calculation of response properties, and it 
+**cannot** calculate these properties without getting contributions like perturbed one- and
+two-electron integrals or solutions of response equations from other codes to which it connects
+through the application programming interface (API). Such a set of API connections can be made
+in quantum chemistry programs the where necessary routines for these contributions are implemented.
 
-Therefore, in order to use OpenRSP for calculations, it is necessary to use a *host program* into which OpenRSP has been incorporated in this way, and a list of such programs is kept at the :ref:`chapter_programs_with_openrsp` page. The specific way in which OpenRSP is invoked in a host program - i.e. the way that you can make OpenRSP calculate something - is a feature of each such program, and you must therefore follow the relevant instructions to achieve this, for example as may be shown in the user manual, for the host program that you want to use.
+Therefore, in order to use OpenRSP for calculations, it is necessary to use a *host program* into
+which OpenRSP has been incorporated in this way, and a list of such programs is kept at the
+:ref:`chapter_programs_with_openrsp` page. The specific way in which OpenRSP is invoked in a host
+program - i.e. the way that you can make OpenRSP calculate something - is a feature of each such
+program, and you must therefore follow the relevant instructions to achieve this, for example as
+may be shown in the user manual, for the host program that you want to use.

--- a/doc/getting_running_openrsp.rst
+++ b/doc/getting_running_openrsp.rst
@@ -1,0 +1,6 @@
+.. _chapter_getting_running_openrsp:
+
+Get and run OpenRSP
+===================
+
+

--- a/doc/getting_running_openrsp.rst
+++ b/doc/getting_running_openrsp.rst
@@ -3,4 +3,6 @@
 Get and run OpenRSP
 ===================
 
+If you want to get OpenRSP and use it for calculations, then please make note of the following: OpenRSP is a program library that manages the calculation of response properties, and it **cannot** calculate these properties without getting contributions like perturbed one- and two-electron integrals or solutions of response equations from other codes to which it connects through the application programming interface (API). Such a set of API connections can be made in quantum chemistry programs the where necessary routines for these contributions are implemented.
 
+Therefore, in order to use OpenRSP for calculations, it is necessary to use a *host program* into which OpenRSP has been incorporated in this way, and a list of such programs is kept at the :ref:`chapter_programs_with_openrsp` page. The specific way in which OpenRSP is invoked in a host program - i.e. the way that you can make OpenRSP calculate something - is a feature of each such program, and you must therefore follow the relevant instructions to achieve this, for example as may be shown in the user manual, for the host program that you want to use.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,12 +14,12 @@ Welcome to the website of OpenRSP - a program library for the open-ended, analyt
    history.rst
    programs_with_openrsp.rst
    papers_openrsp_all.rst
+   theoretical_background.rst
 
 .. toctree::
    :maxdepth: 1
    :caption: Accessing OpenRSP
 
-   theoretical_background.rst
    getting_running_openrsp.rst
    add_openrsp_to_host_program.rst
    get_involved_development.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,22 +17,11 @@ Welcome to the website of OpenRSP - a program library for the open-ended, analyt
 
 .. toctree::
    :maxdepth: 1
-   :caption: Theoretical background
+   :caption: Accessing OpenRSP
 
-   papers_openrsp_theory.rst
-
-
-.. toctree::
-   :maxdepth: 1
-   :caption: How to get and run OpenRSP
-
-.. toctree::
-   :maxdepth: 1
-   :caption: How to add OpenRSP to a quantum chemistry program
-
-
-.. toctree::
-   :maxdepth: 1
-   :caption: How to get involved with developing OpenRSP
+   theoretical_background.rst
+   getting_running_openrsp.rst
+   add_openrsp_to_host_program.rst
+   get_involved_development.rst
 
 

--- a/doc/papers_openrsp_theory.rst
+++ b/doc/papers_openrsp_theory.rst
@@ -1,6 +1,0 @@
-.. _chapter_papers_openrsp_theory:
-
-Papers describing the theory underlying OpenRSP
-===============================================
-
-Add list of papers

--- a/doc/theoretical_background.rst
+++ b/doc/theoretical_background.rst
@@ -1,0 +1,9 @@
+.. _chapter_theoretical_background:
+
+Theoretical background
+======================
+
+
+
+
+chapter_citations

--- a/doc/theoretical_background.rst
+++ b/doc/theoretical_background.rst
@@ -3,7 +3,22 @@
 Theoretical background
 ======================
 
+We are working on a documentation of the OpenRSP core routines and its application programming
+interface (API), and this, together with a introduction of the underlying theory of OpenRSP 
+intended to be accessible will be made available on this website once ready.
 
+In the meantime, for a technical explanation of the theoretical background of OpenRSP, the 
+following references may prove informative:
 
+The paper describing the version of response theory upon which OpenRSP is based.
+* Andreas J. Thorvaldsen, Kenneth Ruud, Kasper Kristensen, Poul Jørgensen and Sonia Coriani, *J. Chem. Phys.* **129**, 214108 (2008)
 
-chapter_citations
+Describes a recursive algorithmic approach for the calculation of response properties:
+* Magnus Ringholm, Dan Jonsson and Kenneth Ruud, *J. Comput. Chem.* **35**, 622-633 (2014)
+
+Describes a recursive algorithmic approach for the calculation of single residues of response functions that can be used to obtain multiphoton absorption matrix elements:
+* Daniel H. Friese, Maarten T. P. Beerepoot, Magnus Ringholm and Kenneth Ruud, *J. Chem. Theory Comput.* **11**, 1129-1144 (2015)
+
+Describes a recursive algorithmic approach for the calculation of single residues of response functions that contain perturbations which affect the basis set (please note that this functionality is not yet implemented in the latest version of OpenRSP):
+* Daniel H. Friese, Magnus Ringholm, Bin Gao and Kenneth Ruud, *J. Chem. Theory Comput.* **11** (10), 4814 (2015)
+

--- a/doc/theoretical_background.rst
+++ b/doc/theoretical_background.rst
@@ -11,14 +11,18 @@ In the meantime, for a technical explanation of the theoretical background of Op
 following references may prove informative:
 
 The paper describing the version of response theory upon which OpenRSP is based.
+
 * Andreas J. Thorvaldsen, Kenneth Ruud, Kasper Kristensen, Poul Jørgensen and Sonia Coriani, *J. Chem. Phys.* **129**, 214108 (2008)
 
 Describes a recursive algorithmic approach for the calculation of response properties:
+
 * Magnus Ringholm, Dan Jonsson and Kenneth Ruud, *J. Comput. Chem.* **35**, 622-633 (2014)
 
 Describes a recursive algorithmic approach for the calculation of single residues of response functions that can be used to obtain multiphoton absorption matrix elements:
+
 * Daniel H. Friese, Maarten T. P. Beerepoot, Magnus Ringholm and Kenneth Ruud, *J. Chem. Theory Comput.* **11**, 1129-1144 (2015)
 
 Describes a recursive algorithmic approach for the calculation of single residues of response functions that contain perturbations which affect the basis set (please note that this functionality is not yet implemented in the latest version of OpenRSP):
+
 * Daniel H. Friese, Magnus Ringholm, Bin Gao and Kenneth Ruud, *J. Chem. Theory Comput.* **11** (10), 4814 (2015)
 


### PR DESCRIPTION
Made new version of the "How to" section of the website. Moved theoretical background to introduction section. Some pages now tell that certain documents like the API description are under development and will be posted once ready. We should now be able to resume work on any remaining contributions at a suitable time.

If this PR is approved, the next step would be a final look at the new `website-overhaul` branch and then a PR from that branch into `master` whereupon the changes will be live.