### PR TITLE
Cleanup debug printing

### DIFF
--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -461,7 +461,7 @@ module rsp_general
           
              if (abs(real(p_tuples(k)%freq(m))) < xtiny) then
              
-               write(out_str, *) 'WARNING: The real part of frequency', np(i), 'of property ', m, 'is nearly zero'
+               write(out_str, *) 'NOTE: The real part of frequency', m, 'of property ', i, 'is zero or nearly zero'
                call out_print(out_str, 1)
                write(out_str, *) 'The value is ', real(p_tuples(k)%freq(m))
                call out_print(out_str, 1)
@@ -476,7 +476,7 @@ module rsp_general
              
              if (abs(aimag(p_tuples(k)%freq(m))) < xtiny) then
              
-               write(out_str, *) 'WARNING: The imaginary part of frequency', np(i), 'of property ', m, 'is nearly zero'
+               write(out_str, *) 'NOTE: The imaginary part of frequency', m, 'of property ', i, 'is zero or nearly zero'
                call out_print(out_str, 1)
                write(out_str, *) 'The value is ', aimag(p_tuples(k)%freq(m))
                call out_print(out_str, 1)

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -206,14 +206,7 @@ module rsp_general
     
     xf_was_allocated = .FALSE.
     
-    ! MaR: Temporarily setting restart flag manually while waiting for API change
-    ! Remove after API change
-    
     r_flag = r_flag_in
-    
-    write(*,*) 'WARNING: Restart flag manually set inside OpenRSP - remove assignment after API change'
-    
-    
     
     if (present(mem_calibrate)) then
     

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -386,7 +386,12 @@ module rsp_perturbed_sdf
     end do
     
     call contrib_cache_deallocate(cache)
-    call contrib_cache_deallocate(lof_cache)
+    
+    if (max_order > 0) then
+    
+       call contrib_cache_deallocate(lof_cache)
+       
+    end if   
     
     deallocate(p_dummy_orders)
     


### PR DESCRIPTION
I cleaned up some debug and progress printing. 

While running tests, I found an error with the cache disassembly routines from last week: For first-order properties, no cache is created for lower-order contributions to the perturbed Fock matrices but deallocation of the cache was still attempted. There is now a check to see if the maximum order of perturbed F, D, S is greater than zero, and if not, then that cache disassembly is not attempted. This was a simple fix and I just did it here.