### PR TITLE
chg 'NUM COMPONENTS' to 'NUM_COMPONENTS' in rsp_tensor printing

### DIFF
--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -711,7 +711,7 @@ module rsp_general
           end do
           
           
-          write(260,*) 'NUM COMPONENTS'
+          write(260,*) 'NUM_COMPONENTS'
           do j = 1, p_tuples(k)%npert
           
              write(260,*) p_tuples(k)%pdim(j)          


### PR DESCRIPTION
## Description

A tiny change to make the keywords printed in the output file consistent

## Motivation and Context

Makes the keywords printed in the output file consistent. Fixes https://github.com/openrsp/openrsp/issues/76 in its present form.

## How Has This Been Tested?

No testing since it's a trivial change

## Questions
<!--- Questions to the developers -->
- [x]  Why are we such great developers?

## Status
<!--- Check this box when ready to be merged -->
- [X]  Ready to go
