### PR TITLE
Rewrote linked list functionality to resizable arrays, rm array constructors in fn/routine calls, other small fixes, all this for Intel/MPI compatibility

### DIFF
--- a/src/ao_dens/rsp_field_tuple.f90
+++ b/src/ao_dens/rsp_field_tuple.f90
@@ -1157,13 +1157,19 @@ end if
     type(p_tuple) :: temporary_pert
     integer :: i, j, new_minimum
 
+write(*,*) 'npt', num_p_tuples
+
     allocate(p_tuples_st(num_p_tuples))
+
+write(*,*) 'allocd'
 
     do i = 1, num_p_tuples
 
        call p1_cloneto_p2(p_tuples(i), p_tuples_st(i))
 
     end do
+
+write(*,*) 'a'
 
     do i = 2, num_p_tuples
 
@@ -1180,17 +1186,20 @@ end if
 
        end do
 
+write(*,*) 'b'
 
        if (.NOT.(new_minimum == i)) then
 
           call p1_cloneto_p2(p_tuples_st(new_minimum),temporary_pert)
           call p_tuple_deallocate(p_tuples_st(new_minimum))
 
+write(*,*) 'c'
           p_tuples_st(i) = p_tuple_standardorder(p_tuples_st(i))
 
           call p1_cloneto_p2(p_tuples_st(i),p_tuples_st(new_minimum))
           call p_tuple_deallocate(p_tuples_st(i))
 
+write(*,*) 'd'
           temporary_pert = p_tuple_standardorder(temporary_pert)
 
           call p1_cloneto_p2(temporary_pert,p_tuples_st(i))
@@ -1199,6 +1208,8 @@ end if
        end if
 
     end do
+
+write(*,*) 'e'
 
   end function
 

--- a/src/ao_dens/rsp_field_tuple.f90
+++ b/src/ao_dens/rsp_field_tuple.f90
@@ -803,9 +803,23 @@ end if
 
     p1%npert = 0
 
-    deallocate(p1%pdim) 
-    deallocate(p1%plab)
-    deallocate(p1%pid)
+    if (allocated(p1%pdim)) then
+        
+        deallocate(p1%pdim)
+        
+    end if
+    
+    if (allocated(p1%plab)) then
+        
+        deallocate(p1%plab)
+        
+    end if
+    
+    if (allocated(p1%pid)) then
+        
+        deallocate(p1%pid)
+        
+    end if
     
     if (allocated(p1%pfcomp)) then
     
@@ -813,7 +827,11 @@ end if
        
     end if    
     
-    deallocate(p1%freq)
+    if (allocated(p1%freq)) then
+    
+        deallocate(p1%freq)
+    
+    end if
     
     if (allocated(p1%states)) then
     
@@ -874,6 +892,8 @@ end if
       type(p_tuple) :: emptypert
       type(p_tuple), optional :: template
 
+      call p_tuple_deallocate(emptypert)
+      
       if (present(template)) then 
       
          call p_tuple_add_stateinfo(emptypert,template)

--- a/src/ao_dens/rsp_field_tuple.f90
+++ b/src/ao_dens/rsp_field_tuple.f90
@@ -1157,19 +1157,17 @@ end if
     type(p_tuple) :: temporary_pert
     integer :: i, j, new_minimum
 
-write(*,*) 'npt', num_p_tuples
+!write(*,*) 'num p tuples', num_p_tuples
 
     allocate(p_tuples_st(num_p_tuples))
 
-write(*,*) 'allocd'
+!write(*,*) ' did alloc'
 
     do i = 1, num_p_tuples
 
        call p1_cloneto_p2(p_tuples(i), p_tuples_st(i))
 
     end do
-
-write(*,*) 'a'
 
     do i = 2, num_p_tuples
 
@@ -1186,20 +1184,16 @@ write(*,*) 'a'
 
        end do
 
-write(*,*) 'b'
-
        if (.NOT.(new_minimum == i)) then
 
           call p1_cloneto_p2(p_tuples_st(new_minimum),temporary_pert)
           call p_tuple_deallocate(p_tuples_st(new_minimum))
 
-write(*,*) 'c'
           p_tuples_st(i) = p_tuple_standardorder(p_tuples_st(i))
 
           call p1_cloneto_p2(p_tuples_st(i),p_tuples_st(new_minimum))
           call p_tuple_deallocate(p_tuples_st(i))
 
-write(*,*) 'd'
           temporary_pert = p_tuple_standardorder(temporary_pert)
 
           call p1_cloneto_p2(temporary_pert,p_tuples_st(i))
@@ -1208,8 +1202,6 @@ write(*,*) 'd'
        end if
 
     end do
-
-write(*,*) 'e'
 
   end function
 

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -554,14 +554,14 @@ module rsp_general
           call out_print(out_str, 1)
 
 
-          call contrib_cache_outer_retrieve(S, 'OPENRSP_S_CACHE', .FALSE.)
-          call contrib_cache_outer_retrieve(D, 'OPENRSP_D_CACHE', .FALSE.)
-          call contrib_cache_outer_retrieve(F, 'OPENRSP_F_CACHE', .FALSE.)
+!           call contrib_cache_outer_retrieve(S, 'OPENRSP_S_CACHE', .FALSE.)
+!           call contrib_cache_outer_retrieve(D, 'OPENRSP_D_CACHE', .FALSE.)
+!           call contrib_cache_outer_retrieve(F, 'OPENRSP_F_CACHE', .FALSE.)
           
           if (residue_order > 0) then
        
              allocate(Xf)
-             call contrib_cache_outer_retrieve(Xf, 'OPENRSP_Xf_CACHE', .FALSE.)
+!              call contrib_cache_outer_retrieve(Xf, 'OPENRSP_Xf_CACHE', .FALSE.)
           
           end if
           
@@ -583,9 +583,9 @@ module rsp_general
          call contrib_cache_outer_add_element(size(D), F, .TRUE., 1, (/get_emptypert()/), &
               data_size = 1, data_mat=(/F_unpert/))
                
-         call contrib_cache_outer_store(S, 'OPENRSP_S_CACHE', r_flag)
-         call contrib_cache_outer_store(D, 'OPENRSP_D_CACHE', r_flag)
-         call contrib_cache_outer_store(F, 'OPENRSP_F_CACHE', r_flag)
+!          call contrib_cache_outer_store(S, 'OPENRSP_S_CACHE', r_flag)
+!          call contrib_cache_outer_store(D, 'OPENRSP_D_CACHE', r_flag)
+!          call contrib_cache_outer_store(F, 'OPENRSP_F_CACHE', r_flag)
          
          if (residue_order > 0) then
        
@@ -593,7 +593,7 @@ module rsp_general
              xf_was_allocated = .TRUE.
              call contrib_cache_outer_add_element(size(Xf), Xf, .TRUE., 1, (/get_emptypert()/), &
                   data_size = 1, data_mat=(/Xf_unpert(1)/))
-             call contrib_cache_outer_store(Xf,'OPENRSP_Xf_CACHE', r_flag)
+!              call contrib_cache_outer_store(Xf,'OPENRSP_Xf_CACHE', r_flag)
           
           end if
        
@@ -854,13 +854,13 @@ module rsp_general
        
        if(.NOT.(sdf_retrieved)) then
        
-          call contrib_cache_outer_retrieve(S, 'OPENRSP_S_CACHE', .FALSE.)
-          call contrib_cache_outer_retrieve(D, 'OPENRSP_D_CACHE', .FALSE.)
-          call contrib_cache_outer_retrieve(F, 'OPENRSP_F_CACHE', .FALSE.)
+!           call contrib_cache_outer_retrieve(S, 'OPENRSP_S_CACHE', .FALSE.)
+!           call contrib_cache_outer_retrieve(D, 'OPENRSP_D_CACHE', .FALSE.)
+!           call contrib_cache_outer_retrieve(F, 'OPENRSP_F_CACHE', .FALSE.)
           
           if (present(Xf)) then
        
-          call contrib_cache_outer_retrieve(Xf, 'OPENRSP_Xf_CACHE', .FALSE.)
+!           call contrib_cache_outer_retrieve(Xf, 'OPENRSP_Xf_CACHE', .FALSE.)
           
           end if
                  
@@ -936,7 +936,7 @@ module rsp_general
     
        if (.NOT.(contrib_retrieved)) then
          
-          call contrib_cache_retrieve(contribution_cache, 'OPENRSP_CONTRIB_CACHE')
+!           call contrib_cache_retrieve(contribution_cache, 'OPENRSP_CONTRIB_CACHE')
           contrib_retrieved = .TRUE.
           
        end if
@@ -989,7 +989,7 @@ module rsp_general
     
        len_cache = size(contribution_cache)
     
-       call contrib_cache_store(len_cache, contribution_cache, r_flag, 'OPENRSP_CONTRIB_CACHE')
+!        call contrib_cache_store(len_cache, contribution_cache, r_flag, 'OPENRSP_CONTRIB_CACHE')
     
     end if
 
@@ -1012,7 +1012,7 @@ module rsp_general
        
           allocate(contribution_cache)
     
-          call contrib_cache_retrieve(contribution_cache, 'OPENRSP_CONTRIB_CACHE')
+!           call contrib_cache_retrieve(contribution_cache, 'OPENRSP_CONTRIB_CACHE')
           contrib_retrieved = .TRUE.
           
        end if
@@ -1075,7 +1075,7 @@ module rsp_general
           
              end if
           
-             call contrib_cache_store(contribution_cache, r_flag, 'OPENRSP_CONTRIB_CACHE')
+!              call contrib_cache_store(contribution_cache, r_flag, 'OPENRSP_CONTRIB_CACHE')
              
           end if
           
@@ -1094,7 +1094,7 @@ module rsp_general
        write(out_str, *) ' '
        call out_print(out_str, 1)
        
-       call contrib_cache_store(contribution_cache, r_flag, 'OPENRSP_CONTRIB_CACHE')
+!        call contrib_cache_store(contribution_cache, r_flag, 'OPENRSP_CONTRIB_CACHE')
     
     end if
     
@@ -1115,7 +1115,7 @@ module rsp_general
     
        if (.NOT.(props_retrieved)) then
        
-          call mat_scal_retrieve(sum(prop_sizes), 'OPENRSP_PROP_CACHE', scal=props)
+!           call mat_scal_retrieve(sum(prop_sizes), 'OPENRSP_PROP_CACHE', scal=props)
           props_retrieved = .TRUE.
           
        end if
@@ -1166,7 +1166,7 @@ module rsp_general
         
           end do
        
-          call mat_scal_store(sum(prop_sizes), 'OPENRSP_PROP_CACHE', r_flag, scal=props)
+!           call mat_scal_store(sum(prop_sizes), 'OPENRSP_PROP_CACHE', r_flag, scal=props)
        
        end if
 
@@ -1197,7 +1197,7 @@ module rsp_general
            
        if (.NOT.(props_retrieved)) then
        
-          call mat_scal_retrieve(sum(prop_sizes), 'OPENRSP_PROP_CACHE', scal=props)
+!           call mat_scal_retrieve(sum(prop_sizes), 'OPENRSP_PROP_CACHE', scal=props)
           props_retrieved = .TRUE.
           
        end if
@@ -1245,7 +1245,7 @@ module rsp_general
        
           end do
        
-          call mat_scal_store(sum(prop_sizes), 'OPENRSP_PROP_CACHE', r_flag, scal=props)
+!           call mat_scal_store(sum(prop_sizes), 'OPENRSP_PROP_CACHE', r_flag, scal=props)
        
        end if
 
@@ -1277,7 +1277,7 @@ module rsp_general
        
           allocate(contribution_cache)
     
-          call contrib_cache_retrieve(contribution_cache, 'OPENRSP_CONTRIB_CACHE')
+!           call contrib_cache_retrieve(contribution_cache, 'OPENRSP_CONTRIB_CACHE')
           contrib_retrieved = .TRUE.
           
        end if
@@ -1327,7 +1327,7 @@ module rsp_general
        end do
     
        len_cache = size(contribution_cache)
-       call contrib_cache_store(len_cache, contribution_cache, r_flag, 'OPENRSP_CONTRIB_CACHE')
+!        call contrib_cache_store(len_cache, contribution_cache, r_flag, 'OPENRSP_CONTRIB_CACHE')
     
     end if
     
@@ -1350,7 +1350,7 @@ module rsp_general
        
           allocate(contribution_cache)
     
-          call contrib_cache_retrieve(contribution_cache, 'OPENRSP_CONTRIB_CACHE')
+!           call contrib_cache_retrieve(contribution_cache, 'OPENRSP_CONTRIB_CACHE')
           contrib_retrieved = .TRUE.
           
        end if
@@ -1411,7 +1411,7 @@ module rsp_general
           
              end if             
              
-             call contrib_cache_store(contribution_cache, r_flag, 'OPENRSP_CONTRIB_CACHE')
+!              call contrib_cache_store(contribution_cache, r_flag, 'OPENRSP_CONTRIB_CACHE')
           
           end if
           
@@ -1430,7 +1430,7 @@ module rsp_general
        write(out_str, *) ' '
        call out_print(out_str, 1)
        
-       call contrib_cache_store(contribution_cache, r_flag, 'OPENRSP_CONTRIB_CACHE')
+!        call contrib_cache_store(contribution_cache, r_flag, 'OPENRSP_CONTRIB_CACHE')
        
     end if
 
@@ -1450,7 +1450,7 @@ module rsp_general
     
        if (.NOT.(props_retrieved)) then
        
-          call mat_scal_retrieve(sum(prop_sizes), 'OPENRSP_PROP_CACHE', scal=props)
+!           call mat_scal_retrieve(sum(prop_sizes), 'OPENRSP_PROP_CACHE', scal=props)
           props_retrieved = .TRUE.
        
        end if
@@ -1502,7 +1502,7 @@ module rsp_general
        
           end do
        
-          call mat_scal_store(sum(prop_sizes), 'OPENRSP_PROP_CACHE', r_flag, scal=props)
+!           call mat_scal_store(sum(prop_sizes), 'OPENRSP_PROP_CACHE', r_flag, scal=props)
        
        end if
   

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -2481,6 +2481,8 @@ module rsp_general
                       allocate(ind_uns(size(cache%contribs_outer(i + 1)%indices(m, :))))
 
                       ind_uns = cache%contribs_outer(i + 1)%indices(m, :)
+                    
+                    write(*,*) 'asking for ind uns', ind_uns
                    
                       call contrib_cache_getdata_outer(size(D), D, 1, &
                            arg_tuple, .FALSE., &
@@ -2519,6 +2521,9 @@ module rsp_general
                      ind_uns = cache%contribs_outer(i + 1)%indices(1 + &
                            (m - 1) * cache%contribs_outer(i + 1)%blks_tuple_triang_size(2), &
                            1:cache%contribs_outer(i + 1)%p_tuples(1)%npert)
+                           
+                           write(*,*) 'my left ind uns', ind_uns
+                           write(*,*) 'it goes into lhs ind', lhs_ctr_2 + m  - 1
 
                       call contrib_cache_getdata_outer(size(D), D, 1, &
                            arg_tuple, .FALSE., &
@@ -2547,6 +2552,9 @@ module rsp_general
                            cache%contribs_outer(i + 1)%p_tuples(1)%npert + 1: &
                            cache%contribs_outer(i + 1)%p_tuples(1)%npert + &
                            cache%contribs_outer(i + 1)%p_tuples(2)%npert)
+                           
+                           write(*,*) 'my right ind uns', ind_uns
+                            write(*,*) 'it goes into rhs ind', rhs_ctr_2 + n  - 1
 
                       call contrib_cache_getdata_outer(size(D), D, 1, &
                            arg_tuple, .FALSE., &
@@ -2587,6 +2595,9 @@ module rsp_general
                   outer_contract_sizes_2(curr_pickup(1):next_pickup(1) - 1, 2), RHS_dmat_2, &
                   cache%blks_triang_size*this_outer_size, &               
                   contrib_2(contrib_offset:contrib_offset + cache%blks_triang_size*this_outer_size - 1))
+      
+             write(*, *) 'Second-order density matrix-dependent contribution(sample)', &
+             contrib_2(1:min(100,size(contrib_2)))
       
              write(out_str, *) 'Second-order density matrix-dependent contribution(sample)', &
              contrib_2(1:min(10,size(contrib_2)))
@@ -2946,10 +2957,10 @@ module rsp_general
                       deallocate(arg_int_b)
                       deallocate(arg_int)
 
-!                       write(*,*) 'Index tuple:', (/cache%indices(j, :), cache%contribs_outer(m)%indices(i, :)/)
-!                       write(*,*) 'Saving element', j + size(cache%indices, 1) * (i - 1), &
-!                       'of data in cache element', offset
-!                       write(*,*) 'data is',  data_tmp(j + size(cache%indices, 1) * (i - 1))
+                       write(*,*) 'Index tuple:', (/cache%indices(j, :), cache%contribs_outer(m)%indices(i, :)/)
+                       write(*,*) 'Saving element', j + size(cache%indices, 1) * (i - 1), &
+                       'of data in cache element', offset
+                       write(*,*) 'data is',  data_tmp(j + size(cache%indices, 1) * (i - 1))
                    
                       cache%contribs_outer(m)%data_scal(offset) = data_tmp(j + &
                       size(cache%indices, 1) * (i - 1))

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -576,7 +576,7 @@ module rsp_general
               data_size = 1, data_mat=(/S_unpert/))
          call contrib_cache_outer_add_element(size(D), D, .TRUE., 1, (/get_emptypert()/), &
               data_size = 1, data_mat=(/D_unpert/))
-         call contrib_cache_outer_add_element(size(D), F, .TRUE., 1, (/get_emptypert()/), &
+         call contrib_cache_outer_add_element(size(F), F, .TRUE., 1, (/get_emptypert()/), &
               data_size = 1, data_mat=(/F_unpert/))
                
 !          call contrib_cache_outer_store(S, 'OPENRSP_S_CACHE', r_flag)

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -918,6 +918,8 @@ module rsp_general
        
     end if
     
+    ! DEC 19: CONTINUE HERE AFTER RETURNING FROM SDF
+    
     ! Check if this stage passed previously and if so, then retrieve and skip execution
     
     call prog_incr(prog_info, r_flag, 1)

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -153,7 +153,7 @@ module rsp_general
     external :: get_rsp_sol, get_ovl_mat, get_ovl_exp, get_1el_mat, get_1el_exp, get_nucpot
     external :: get_2el_mat, get_2el_exp, get_xc_mat, get_xc_exp
     external :: out_print
-    character(len=2047) :: out_str
+!    character(len=2047) :: out_str
     integer(kind=QINT), intent(in) :: rsp_tensor_size
     complex(8), dimension(rsp_tensor_size) :: rsp_tensor
     type(QcMat) :: S_unpert, D_unpert, F_unpert ! NOTE: Make optional to exclude in mem. calibration mode
@@ -174,7 +174,7 @@ module rsp_general
     integer, optional :: max_mat, mem_result
     logical :: xf_was_allocated
     type(mem_manager) :: mem_mgr
-    
+   character(len=1048576) :: out_str    
     integer(kind=QINT), intent(in), optional :: residue_spec_pert(residue_order)
     integer(kind=QINT), intent(in), optional :: size_rsi_1
     integer(kind=QINT), dimension(*), optional :: residue_spec_index
@@ -271,8 +271,8 @@ module rsp_general
     ! Present calculation and initialize perturbation tuple datatypes and
     ! associated size/indexing information
 
-    write(out_str, *) ' '
-    call out_print(out_str, 1)
+   write(out_str, *) ' '
+   call out_print(out_str, 1)
     
     if (residue_order == 0) then
     
@@ -994,8 +994,6 @@ module rsp_general
                   len_cache, contribution_cache, prop_sizes(k), &
                   props(sum(prop_sizes(1:k)) - prop_sizes(k) + 1:sum(prop_sizes(1:k))))
              call cpu_time(time_end)
-
-write(*,*) 'stage 1'
 
              write(out_str, *) ' '
              call out_print(out_str, 1)

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -2588,8 +2588,6 @@ module rsp_general
                   cache%blks_triang_size*this_outer_size, &               
                   contrib_2(contrib_offset:contrib_offset + cache%blks_triang_size*this_outer_size - 1))
       
-             write(*, *) 'Second-order density matrix-dependent contribution(sample)', &
-             contrib_2(1:min(100,size(contrib_2)))
       
              write(out_str, *) 'Second-order density matrix-dependent contribution(sample)', &
              contrib_2(1:min(10,size(contrib_2)))

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -586,11 +586,11 @@ module rsp_general
          call empty_p_tuple(empty_pert(1))
 
          call contrib_cache_outer_add_element(size(S), S, .TRUE., 1, empty_pert, &
-              data_size = 1, data_mat=S_unpert)
+              data_size = 1, data_mat=S_unpert_arr)
          call contrib_cache_outer_add_element(size(D), D, .TRUE., 1, empty_pert, &
-              data_size = 1, data_mat=D_unpert)
+              data_size = 1, data_mat=D_unpert_arr)
          call contrib_cache_outer_add_element(size(F), F, .TRUE., 1, empty_pert, &
-              data_size = 1, data_mat=F_unpert)
+              data_size = 1, data_mat=F_unpert_arr)
                
 !          call contrib_cache_outer_store(S, 'OPENRSP_S_CACHE', r_flag)
 !          call contrib_cache_outer_store(D, 'OPENRSP_D_CACHE', r_flag)

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -3331,27 +3331,28 @@ module rsp_general
        
        traverse_end = .FALSE.
        
-       outer_next => contrib_cache_outer_cycle_first(outer_next)
-       if (outer_next%dummy_entry) then
-          outer_next => outer_next%next
-       end if
-     
        o_ctr = 1
        mctr = 0
        
        k = 1
        
        ! Traverse to get W matrices
-       do while (traverse_end .EQV. .FALSE.)
+       do m = 1, size(cache%contribs_outer)
+    
+          if (cache%contribs_outer(m)%dummy_entry) then
+       
+             cycle
+          
+          end if
      
              allocate(d_struct_o(o_supsize(k), 3))
              allocate(d_struct_o_prime(o_supsize_prime(k), 3))
              
              which_index_is_pid = 0
              
-             do j = 1, outer_next%p_tuples(1)%npert
+             do j = 1, cache%contribs_outer(m)%p_tuples(1)%npert
              
-                which_index_is_pid(outer_next%p_tuples(1)%pid(j)) = j
+                which_index_is_pid(cache%contribs_outer(m)%p_tuples(1)%pid(j)) = j
              
              end do
              
@@ -3359,12 +3360,14 @@ module rsp_general
    
              ! Get derivative superstructures according to whether contribution
              ! is n or Lagrange
-             if(outer_next%p_tuples(1)%npert ==0) then
+             if(cache%contribs_outer(m)%p_tuples(1)%npert ==0) then
              
-                if (outer_next%contrib_type == 1 .OR. outer_next%contrib_type == 4) then
+                if (cache%contribs_outer(m)%contrib_type == 1 .OR. &
+                    cache%contribs_outer(m)%contrib_type == 4) then
                        
                    call derivative_superstructure(get_emptypert(), &
-                   (/outer_next%n_rule, outer_next%n_rule/), .FALSE., &
+                   (/cache%contribs_outer(m)%n_rule, &
+                   cache%contribs_outer(m)%n_rule/), .FALSE., &
                    (/get_emptypert(), get_emptypert(), get_emptypert()/), &
                    o_supsize(k), sstr_incr, d_struct_o)
                    
@@ -3372,10 +3375,12 @@ module rsp_general
                 
                 end if
                
-                if (outer_next%contrib_type == 3 .OR. outer_next%contrib_type == 4) then
+                if (cache%contribs_outer(m)%contrib_type == 3 .OR. &
+                    cache%contribs_outer(m)%contrib_type == 4) then
                 
                    call derivative_superstructure(get_emptypert(), &
-                   (/outer_next%n_rule, outer_next%n_rule/), .TRUE., &
+                   (/cache%contribs_outer(m)%n_rule, &
+                   cache%contribs_outer(m)%n_rule/), .TRUE., &
                    (/get_emptypert(), get_emptypert(), get_emptypert()/), &
                    o_supsize_prime(k), sstr_incr, d_struct_o)
                       
@@ -3387,10 +3392,12 @@ module rsp_general
              
              else
          
-                if (outer_next%contrib_type == 1 .OR. outer_next%contrib_type == 4) then             
+                if (cache%contribs_outer(m)%contrib_type == 1 .OR. &
+                    cache%contribs_outer(m)%contrib_type == 4) then             
          
-                   call derivative_superstructure(outer_next%p_tuples(1), &
-                   (/outer_next%n_rule, outer_next%n_rule/), .FALSE., &
+                   call derivative_superstructure(cache%contribs_outer(m)%p_tuples(1), &
+                   (/cache%contribs_outer(m)%n_rule, &
+                   cache%contribs_outer(m)%n_rule/), .FALSE., &
                    (/get_emptypert(), get_emptypert(), get_emptypert()/), &
                    o_supsize(k), sstr_incr, d_struct_o)
                    
@@ -3398,10 +3405,12 @@ module rsp_general
                 
                 end if
       
-               if (outer_next%contrib_type == 3 .OR. outer_next%contrib_type == 4) then
+               if (cache%contribs_outer(m)%contrib_type == 3 .OR. &
+                   cache%contribs_outer(m)%contrib_type == 4) then
                 
-                   call derivative_superstructure(outer_next%p_tuples(1), &
-                   (/outer_next%n_rule, outer_next%n_rule/), .TRUE., &
+                   call derivative_superstructure(cache%contribs_outer(m)%p_tuples(1), &
+                   (/cache%contribs_outer(m)%n_rule, &
+                   cache%contribs_outer(m)%n_rule/), .TRUE., &
                    (/get_emptypert(), get_emptypert(), get_emptypert()/), &
                    o_supsize_prime(k), sstr_incr, d_struct_o_prime)
                    
@@ -3409,7 +3418,7 @@ module rsp_general
                    
                 end if
      
-                o_triang_size = size(outer_next%indices, 1)
+                o_triang_size = size(cache%contribs_outer(m)%indices, 1)
                 
              end if
      
@@ -3418,7 +3427,7 @@ module rsp_general
              
                 if ((o_ctr == mcurr + mctr) .AND. .NOT.(msize <= mctr)) then
                 
-                   select case (outer_next%contrib_type)
+                   select case (cache%contribs_outer(m)%contrib_type)
                 
                    ! Only Pulay n
                    case (1)
@@ -3428,10 +3437,12 @@ module rsp_general
                       if (.NOT.(mem_mgr%calibrate)) then
                 
                          call rsp_get_matrix_w(o_supsize(k), d_struct_o, cache%p_inner%npert + &
-                              outer_next%p_tuples(1)%npert, &
+                              cache%contribs_outer(m)%p_tuples(1)%npert, &
                               which_index_is_pid(1:cache%p_inner%npert + &
-                              outer_next%p_tuples(1)%npert), size(outer_next%indices(j,:)), &
-                              outer_next%indices(j,:), F, D, S, W(mctr + 1))
+                              cache%contribs_outer(m)%p_tuples(1)%npert), &
+                              size(cache%contribs_outer(m)%indices(j,:)), &
+                              cache%contribs_outer(m)%indices(j,:), &
+                              size(F), F, size(D), D, size(S), S, W(mctr + 1))
                       
                       end if
                            
@@ -3445,10 +3456,11 @@ module rsp_general
                       if (.NOT.(mem_mgr%calibrate)) then                
                 
                          call rsp_get_matrix_w(o_supsize_prime(k), d_struct_o_prime, &
-                              cache%p_inner%npert + outer_next%p_tuples(1)%npert, &
+                              cache%p_inner%npert + cache%contribs_outer(m)%p_tuples(1)%npert, &
                               which_index_is_pid(1:cache%p_inner%npert + &
-                              outer_next%p_tuples(1)%npert), size(outer_next%indices(j,:)), &
-                              outer_next%indices(j,:), F, D, S, W(mctr + 1))
+                              cache%contribs_outer(m)%p_tuples(1)%npert), & size(cache%contribs_outer(m)%indices(j,:)), &
+                              cache%contribs_outer(m)%indices(j,:), &
+                              size(F), F, size(D), D, size(S), S, W(mctr + 1))
                            
                       end if
                            
@@ -3462,10 +3474,11 @@ module rsp_general
                       if (.NOT.(mem_mgr%calibrate)) then                     
                    
                          call rsp_get_matrix_w(o_supsize(k), d_struct_o, cache%p_inner%npert + &
-                              outer_next%p_tuples(1)%npert, &
+                              cache%contribs_outer(m)%p_tuples(1)%npert, &
                               which_index_is_pid(1:cache%p_inner%npert + &
-                              outer_next%p_tuples(1)%npert), size(outer_next%indices(j,:)), &
-                              outer_next%indices(j,:), F, D, S, W(mctr + 1))
+                              cache%contribs_outer(m)%p_tuples(1)%npert), & size(cache%contribs_outer(m)%indices(j,:)), &
+                              cache%contribs_outer(m)%indices(j,:), &
+                              size(F), F, size(D), D, size(S), S, W(mctr + 1))
                            
                       end if
                            
@@ -3482,7 +3495,7 @@ module rsp_general
              end do
              
              ! If contribution type is 4, loop to get Pulay Lagrange matrices
-             if (outer_next%contrib_type == 4) then
+             if (cache%contribs_outer(m)%contrib_type == 4) then
              
                 ! Calculate matrices
                 do j = 1, o_triang_size
@@ -3494,10 +3507,11 @@ module rsp_general
                       if (.NOT.(mem_mgr%calibrate)) then   
                          
                          call rsp_get_matrix_w(o_supsize_prime(k), d_struct_o_prime, &
-                              cache%p_inner%npert + outer_next%p_tuples(1)%npert, &
+                              cache%p_inner%npert + cache%contribs_outer(m)%p_tuples(1)%npert, &
                               which_index_is_pid(1:cache%p_inner%npert + &
-                              outer_next%p_tuples(1)%npert), size(outer_next%indices(j,:)), &
-                              outer_next%indices(j,:), F, D, S, W(mctr + 1))
+                              cache%contribs_outer(m)%p_tuples(1)%npert), & size(cache%contribs_outer(m)%indices(j,:)), &
+                              cache%contribs_outer(m)%indices(j,:), &
+                              size(F), F, size(D), D, size(S), S, W(mctr + 1))
                               
                       end if
                            
@@ -3516,16 +3530,8 @@ module rsp_general
           
              deallocate(d_struct_o)
              deallocate(d_struct_o_prime)
-          
-          if (outer_next%last) then
-       
-             traverse_end = .TRUE.
-       
-          end if
-       
+                
           k = k + 1
-       
-          outer_next => outer_next%next
        
        end do
        
@@ -3558,47 +3564,47 @@ module rsp_general
     
     end do
     ! End memory management loop 1
-    
-    
    
     contrib_pulay = -2.0 * contrib_pulay
-    
     
     ! Traversal: Store Pulay contributions
     
     traverse_end = .FALSE.
     
-    outer_next => contrib_cache_outer_cycle_first(outer_next)
-    if (outer_next%dummy_entry) then
-       outer_next => outer_next%next
-    end if
-    
     k = 1
     o_ctr = 0
     
-    do while (traverse_end .EQV. .FALSE.)
+    ! Traversal: Store Pulay contributions
+    do m = 1, size(cache%contribs_outer)
+    
+       if (cache%contribs_outer(m)%dummy_entry) then
+       
+          cycle
+          
+       end if
 
        c_ctr = 0
     
-       if (outer_next%p_tuples(1)%npert ==0) then
+       if (cache%contribs_outer(m)%p_tuples(1)%npert ==0) then
           
           o_triang_size = 1
           
        else
       
-          o_triang_size = size(outer_next%indices, 1)
+          o_triang_size = size(cache%contribs_outer(m)%indices, 1)
              
        end if
        
        ! Set up block information for indexing
        
        tot_num_pert = cache%p_inner%npert + &
-       sum((/(outer_next%p_tuples(m)%npert, m = 1, outer_next%num_dmat)/))
+       sum((/(cache%contribs_outer(m)%p_tuples(m)%npert, m = 1, &
+              cache%contribs_outer(m)%num_dmat)/))
                    
-       allocate(blks_tuple_info(outer_next%num_dmat + 1,tot_num_pert, 3))
-       allocate(blk_sizes(outer_next%num_dmat + 1, tot_num_pert))
+       allocate(blks_tuple_info(cache%contribs_outer(m)%num_dmat + 1,tot_num_pert, 3))
+       allocate(blk_sizes(cache%contribs_outer(m)%num_dmat + 1, tot_num_pert))
                
-       do j = 1, outer_next%num_dmat + 1
+       do j = 1, cache%contribs_outer(m)%num_dmat + 1
           
           if (j == 1) then
              
@@ -3612,22 +3618,24 @@ module rsp_general
           
           else
              
-             if (size(outer_next%p_tuples) > 0) then
+             if (size(cache%contribs_outer(m)%p_tuples) > 0) then
                 
-                if (outer_next%p_tuples(1)%npert > 0) then
+                if (cache%contribs_outer(m)%p_tuples(1)%npert > 0) then
                    
-                   do m = 1, outer_next%nblks_tuple(j - 1)
+                   do m = 1, cache%contribs_outer(m)%nblks_tuple(j - 1)
                       
                       do p = 1, 3
                          
-                         blks_tuple_info(j, m, :) = outer_next%blks_tuple_info(j - 1, m, :)
+                         blks_tuple_info(j, m, :) = &
+                         cache%contribs_outer(m)%blks_tuple_info(j - 1, m, :)
                       
                       end do
                    
                    end do
                    
-                   blk_sizes(j, 1:outer_next%nblks_tuple(j-1)) = &
-                   outer_next%blk_sizes(j-1, 1:outer_next%nblks_tuple(j-1))
+                   blk_sizes(j, 1:cache%contribs_outer(m)%nblks_tuple(j-1)) = &
+                   cache%contribs_outer(m)%blk_sizes(j-1, &
+                   1:cache%contribs_outer(m)%nblks_tuple(j-1))
                 
                 end if
              
@@ -3644,17 +3652,18 @@ module rsp_general
           
           do j = 1, size(cache%indices, 1)
                
-             if (size(outer_next%p_tuples) > 0) then
+             if (size(cache%contribs_outer(m)%p_tuples) > 0) then
              
-                if (outer_next%p_tuples(1)%npert > 0) then
+                if (cache%contribs_outer(m)%p_tuples(1)%npert > 0) then
 
                    offset = get_triang_blks_tuple_offset(2, tot_num_pert, &
-                   (/cache%nblks, outer_next%nblks_tuple(1)/), &
-                   (/cache%p_inner%npert, outer_next%p_tuples(1)%npert/), &
+                   (/cache%nblks, cache%contribs_outer(m)%nblks_tuple(1)/), &
+                   (/cache%p_inner%npert, cache%contribs_outer(m)%p_tuples(1)%npert/), &
                    blks_tuple_info, &
                    blk_sizes, &
-                   (/cache%blks_triang_size, outer_next%blks_tuple_triang_size(1)/), &
-                   (/cache%indices(j, :), outer_next%indices(i, :)/))
+                   (/cache%blks_triang_size, &
+                   (/cache%contribs_outer(m)%blks_tuple_triang_size(1)/), &
+                   (/cache%indices(j, :), cache%contribs_outer(m)%indices(i, :)/))
                       
                 else
                    
@@ -3664,25 +3673,26 @@ module rsp_general
                    
              end if
                 
-             if (outer_next%contrib_type == 1) then
+             if (cache%contribs_outer(m)%contrib_type == 1) then
                 
-                outer_next%data_scal(offset) = contrib_pulay(j + &
+                cache%contribs_outer(m)%data_scal(offset) = contrib_pulay(j + &
                 size(cache%indices, 1) * (i - 1) + o_ctr)
                 c_ctr = c_ctr + 1
                    
-             else if (outer_next%contrib_type == 3) then
+             else if (cache%contribs_outer(m)%contrib_type == 3) then
 
-                outer_next%data_scal(offset) = contrib_pulay(j + &
+                cache%contribs_outer(m)%data_scal(offset) = contrib_pulay(j + &
                 size(cache%indices, 1) * (i - 1) + o_ctr)
                 c_ctr = c_ctr + 1
                    
-             else if (outer_next%contrib_type == 4) then
+             else if (cache%contribs_outer(m)%contrib_type == 4) then
                 
-                outer_next%data_scal(offset) = contrib_pulay(j + &
+                cache%contribs_outer(m)%data_scal(offset) = contrib_pulay(j + &
                 size(cache%indices, 1) * (i - 1) + o_ctr)
                    
                 ! Skip one block to store Pulay Lagrange when both Pulay n and Lagrange
-                outer_next%data_scal(offset + size(cache%indices, 1) * o_triang_size) = &
+                cache%contribs_outer(m)%data_scal(offset + &
+                size(cache%indices, 1) * o_triang_size) = &
                 contrib_pulay(j + size(cache%indices, 1) * (i - 1) + &
                 size(cache%indices, 1) * o_triang_size  + o_ctr)
                 c_ctr = c_ctr + 2
@@ -3699,16 +3709,8 @@ module rsp_general
        deallocate(blk_sizes)
        deallocate(blks_tuple_info)
        
-       if (outer_next%last) then
-    
-          traverse_end = .TRUE.
-    
-       end if
-       
        k = k + 1
        
-       outer_next => outer_next%next
-    
     end do
     
     deallocate(contrib_pulay)
@@ -3796,14 +3798,15 @@ module rsp_general
                      lagrange_max_n/), i_supsize, d_struct_inner, maxval(cache%p_inner%pid), &
                      which_index_is_pid(1:maxval(cache%p_inner%pid)), &
                      size(cache%indices(mcurr + i - 1,:)), &
-                     cache%indices(mcurr + i - 1,:), F, D, S, Zeta(i), &
+                     cache%indices(mcurr + i - 1,:), size(F), F, size(D), D, &
+                     size(S), S, Zeta(i), &
                      select_terms_arg = select_terms)
                      
                 call rsp_get_matrix_lambda(p_tuple_getone(cache%p_inner, 1), i_supsize, &
                      d_struct_inner, maxval(cache%p_inner%pid), &
                      which_index_is_pid(1:maxval(cache%p_inner%pid)), &
                      size(cache%indices(mcurr + i - 1,:)), cache%indices(mcurr + i - 1,:), &
-                     D, S, Lambda(i), select_terms_arg = select_terms)
+                     size(D), D, size(S), S, Lambda(i), select_terms_arg = select_terms)
       
              end do
              
@@ -3811,16 +3814,6 @@ module rsp_general
        
           
          
-
-         
-         ! Traversal: Calculate/store idempotency/SCFE contributions
-          
-          traverse_end = .FALSE.
-          
-          outer_next => contrib_cache_outer_cycle_first(outer_next)
-          if (outer_next%dummy_entry) then
-             outer_next => outer_next%next
-          end if
           
           call mem_incr(mem_mgr, 1)
           call mem_incr(mem_mgr, 1)
@@ -3836,30 +3829,40 @@ module rsp_general
           
           k = 1
           o_ctr = 0
+
+          ! Traversal: Calculate/store idempotency/SCFE contributions
+          do m = 1, size(cache%contribs_outer)
+    
+             if (cache%contribs_outer(m)%dummy_entry) then
+       
+                cycle
+          
+             end if
           
           do while (traverse_end .EQV. .FALSE.)
       
              c_ctr = 0
           
-             if (outer_next%p_tuples(1)%npert ==0) then
+             if (cache%contribs_outer(m)%p_tuples(1)%npert ==0) then
                 
                 o_triang_size = 1
                
              else
             
-               o_triang_size = size(outer_next%indices, 1)
+               o_triang_size = size(cache%contribs_outer(m)%indices, 1)
                    
              end if
              
              ! Set up block information for indexing
              
              tot_num_pert = cache%p_inner%npert + &
-             sum((/(outer_next%p_tuples(m)%npert, m = 1, outer_next%num_dmat)/))
+             sum((/(cache%contribs_outer(m)%p_tuples(m)%npert, m = 1, &
+             cache%contribs_outer(m)%num_dmat)/))
                          
-             allocate(blks_tuple_info(outer_next%num_dmat + 1,tot_num_pert, 3))
-             allocate(blk_sizes(outer_next%num_dmat + 1, tot_num_pert))
+             allocate(blks_tuple_info(cache%contribs_outer(m)%num_dmat + 1,tot_num_pert, 3))
+             allocate(blk_sizes(cache%contribs_outer(m)%num_dmat + 1, tot_num_pert))
                      
-             do j = 1, outer_next%num_dmat + 1
+             do j = 1, cache%contribs_outer(m)%num_dmat + 1
                 
                 if (j == 1) then
                    
@@ -3873,22 +3876,24 @@ module rsp_general
                 
                 else
                
-                   if (size(outer_next%p_tuples) > 0) then
+                   if (size(cache%contribs_outer(m)%p_tuples) > 0) then
                       
-                      if (outer_next%p_tuples(1)%npert > 0) then
+                      if (cache%contribs_outer(m)%p_tuples(1)%npert > 0) then
                          
-                         do m = 1, outer_next%nblks_tuple(j - 1)
+                         do m = 1, cache%contribs_outer(m)%nblks_tuple(j - 1)
                            
                             do p = 1, 3
                                
-                              blks_tuple_info(j, m, :) = outer_next%blks_tuple_info(j - 1, m, :)
+                              blks_tuple_info(j, m, :) = &
+                              cache%contribs_outer(m)%blks_tuple_info(j - 1, m, :)
                             
                             end do
                          
                          end do
                          
-                         blk_sizes(j, 1:outer_next%nblks_tuple(j-1)) = &
-                         outer_next%blk_sizes(j-1, 1:outer_next%nblks_tuple(j-1))
+                         blk_sizes(j, 1:cache%contribs_outer(m)%nblks_tuple(j-1)) = &
+                         cache%contribs_outer(m)%blk_sizes(j-1, &
+                         1:cache%contribs_outer(m)%nblks_tuple(j-1))
                       
                       end if
                   
@@ -3900,11 +3905,12 @@ module rsp_general
              
              ! Set up counters to store idempotency, SCFE terms in correct positions
              
-             if ((outer_next%contrib_type == 1) .OR. (outer_next%contrib_type == 3)) then
+             if ((cache%contribs_outer(m)%contrib_type == 1) .OR. &
+             (cache%contribs_outer(m)%contrib_type == 3)) then
              
                 c_snap = o_triang_size * size(cache%indices,1)
       
-             else if (outer_next%contrib_type == 4) then
+             else if (cache%contribs_outer(m)%contrib_type == 4) then
       
                 c_snap = 2 * o_triang_size * size(cache%indices,1)
                       
@@ -3913,33 +3919,36 @@ module rsp_general
              o_ctr = o_ctr + c_snap
             
              ! Calculate and store idempotency and SCFE terms
-             if ((outer_next%contrib_type == 3) .OR. (outer_next%contrib_type == 4)) then
+             if ((cache%contribs_outer(m)%contrib_type == 3) .OR. &
+             (cache%contribs_outer(m)%contrib_type == 4)) then
            
                 allocate(d_struct_o(o_supsize_prime(k), 3))
         
                 
                 which_index_is_pid = 0
                 
-                do j = 1, outer_next%p_tuples(1)%npert
+                do j = 1, cache%contribs_outer(m)%p_tuples(1)%npert
                 
-                   which_index_is_pid(outer_next%p_tuples(1)%pid(j)) = j
+                   which_index_is_pid(cache%contribs_outer(m)%p_tuples(1)%pid(j)) = j
                  
                 end do
                 
                 sstr_incr = 0
                 
                 ! Get derivative superstructures
-                if(outer_next%p_tuples(1)%npert ==0) then
+                if(cache%contribs_outer(m)%p_tuples(1)%npert ==0) then
                 
                    call derivative_superstructure(get_emptypert(), &
-                   (/outer_next%n_rule, outer_next%n_rule/), .TRUE., &
+                   (/cache%contribs_outer(m)%n_rule, &
+                   cache%contribs_outer(m)%n_rule/), .TRUE., &
                    (/get_emptypert(), get_emptypert(), get_emptypert()/), &
                    o_supsize_prime(k), sstr_incr, d_struct_o)
                    
                  else
             
-                   call derivative_superstructure(outer_next%p_tuples(1), &
-                   (/outer_next%n_rule, outer_next%n_rule/), .TRUE., &
+                   call derivative_superstructure(cache%contribs_outer(m)%p_tuples(1), &
+                   (/cache%contribs_outer(m)%n_rule, &
+                   cache%contribs_outer(m)%n_rule/), .TRUE., &
                    (/get_emptypert(), get_emptypert(), get_emptypert()/), &
                    o_supsize_prime(k), sstr_incr, d_struct_o)
                   
@@ -3954,10 +3963,12 @@ module rsp_general
         
                       call QcMatZero(Y)
                       call rsp_get_matrix_y(o_supsize_prime(k), d_struct_o, cache%p_inner%npert + &
-                           outer_next%p_tuples(1)%npert, &
+                           cache%contribs_outer(m)%p_tuples(1)%npert, &
                            which_index_is_pid(1:cache%p_inner%npert + &
-                           outer_next%p_tuples(1)%npert), size(outer_next%indices(i,:)), outer_next%indices(i,:), &
-                           F, D, S, Y, select_terms_arg = .FALSE.)
+                           cache%contribs_outer(m)%p_tuples(1)%npert), &
+                           size(cache%contribs_outer(m)%indices(i,:)), &
+                           cache%contribs_outer(m)%indices(i,:), &
+                           size(F), F, size(D), D, size(S), S, Y, select_terms_arg = .FALSE.)
                            
                    end if
                    
@@ -3971,11 +3982,13 @@ module rsp_general
                       ! have another look if something goes wrong
                       call QcMatZero(Z)
                       call rsp_get_matrix_z(o_supsize_prime(k), d_struct_o, &
-                           (/outer_next%n_rule, outer_next%n_rule/), cache%p_inner%npert + &
-                           outer_next%p_tuples(1)%npert, &
+                           (/cache%contribs_outer(m)%n_rule, cache%contribs_outer(m)%n_rule/), &
+                           cache%p_inner%npert + &
+                           cache%contribs_outer(m)%p_tuples(1)%npert, &
                            which_index_is_pid(1:cache%p_inner%npert + &
-                           outer_next%p_tuples(1)%npert), size(outer_next%indices(i,:)), outer_next%indices(i,:), &
-                           F, D, S, Z, select_terms_arg = .FALSE.)
+                           cache%contribs_outer(m)%p_tuples(1)%npert), & size(cache%contribs_outer(m)%indices(i,:)), &
+                           cache%contribs_outer(m)%indices(i,:), &
+                           size(F), F, size(D), D, size(S), S, Z, select_terms_arg = .FALSE.)
                            
                    end if
                   
@@ -3983,16 +3996,17 @@ module rsp_general
                                          
                    do j = mcurr, mcurr + msize - 1
                  
-                      if (size(outer_next%p_tuples) > 0) then
-                         if (outer_next%p_tuples(1)%npert > 0) then
+                      if (size(cache%contribs_outer(m)%p_tuples) > 0) then
+                         if (cache%contribs_outer(m)%p_tuples(1)%npert > 0) then
         
                             offset = get_triang_blks_tuple_offset(2, tot_num_pert, &
-                            (/cache%nblks, outer_next%nblks_tuple(1)/), &
-                            (/cache%p_inner%npert, outer_next%p_tuples(1)%npert/), &
+                            (/cache%nblks, cache%contribs_outer(m)%nblks_tuple(1)/), &
+                            (/cache%p_inner%npert, cache%contribs_outer(m)%p_tuples(1)%npert/), &
                             blks_tuple_info, &
                             blk_sizes, &
-                            (/cache%blks_triang_size, outer_next%blks_tuple_triang_size(1)/), &
-                            (/cache%indices(j, :), outer_next%indices(i, :)/))
+                            (/cache%blks_triang_size, &
+                            (/cache%contribs_outer(m)%blks_tuple_triang_size(1)/), &
+                            (/cache%indices(j, :), cache%contribs_outer(m)%indices(i, :)/))
                          
                          else
                       
@@ -4006,16 +4020,18 @@ module rsp_general
                       
 !                          write(*,*) 'Saving element', j, 'of data in', offset
                       
-                         call QcMatTraceAB(Zeta(j), Z, outer_next%data_scal(c_snap + offset))
-                         call QcMatTraceAB(Lambda(j), Y, outer_next%data_scal(c_snap + &
+                         call QcMatTraceAB(Zeta(j), Z, &
+                         cache%contribs_outer(m)%data_scal(c_snap + offset))
+                         call QcMatTraceAB(Lambda(j), Y, &
+                         cache%contribs_outer(m)%data_scal(c_snap + &
                          cache%blks_triang_size*o_triang_size + offset))
                    
-                         outer_next%data_scal(c_snap + offset) = &
-                         -2.0 * outer_next%data_scal(c_snap + offset)
+                         cache%contribs_outer(m)%data_scal(c_snap + offset) = &
+                         -2.0 * cache%contribs_outer(m)%data_scal(c_snap + offset)
                    
-                         outer_next%data_scal(c_snap + &
+                         cache%contribs_outer(m)%data_scal(c_snap + &
                          cache%blks_triang_size*o_triang_size + offset) = &
-                         -2.0 * outer_next%data_scal(c_snap + &
+                         -2.0 * cache%contribs_outer(m)%data_scal(c_snap + &
                          cache%blks_triang_size*o_triang_size + offset)
                          
                       end if
@@ -4031,16 +4047,8 @@ module rsp_general
              deallocate(blk_sizes)
              deallocate(blks_tuple_info)
           
-             if (outer_next%last) then
-    
-                traverse_end = .TRUE.
-    
-             end if
-       
              k = k + 1
        
-             outer_next => outer_next%next
-
           end do
           
           if (.NOT.(mem_mgr%calibrate)) then

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -883,7 +883,7 @@ module rsp_general
        
        if (present(Xf)) then
        
-          call rsp_fds(n_props, n_freq_cfgs, p_tuples, kn_rule, F, D, S, &
+          call rsp_fds(n_props, n_freq_cfgs, p_tuples, kn_rule, size(D), F, D, S, &
                        get_rsp_sol, get_ovl_mat, get_1el_mat, &
                        get_2el_mat, get_xc_mat, out_print, .TRUE., &
                        prog_info, rs_info, r_flag, sdf_retrieved, mem_mgr, Xf=Xf)
@@ -891,7 +891,7 @@ module rsp_general
                        
        else
        
-          call rsp_fds(n_props, n_freq_cfgs, p_tuples, kn_rule, F, D, S, &
+          call rsp_fds(n_props, n_freq_cfgs, p_tuples, kn_rule, size(D), F, D, S, &
                        get_rsp_sol, get_ovl_mat, get_1el_mat, &
                        get_2el_mat, get_xc_mat, out_print, .TRUE., &
                        prog_info, rs_info, r_flag, sdf_retrieved, mem_mgr)
@@ -964,7 +964,7 @@ module rsp_general
 
              call cpu_time(time_start)
              call rsp_energy_recurse(p_tuples(k), p_tuples(k)%npert, kn_rule(k,:), 1, (/emptypert/), &
-                  0, D, get_nucpot, get_1el_exp, get_ovl_exp, get_2el_exp, out_print, .TRUE., &
+                  0, size(D), D, get_nucpot, get_1el_exp, get_ovl_exp, get_2el_exp, out_print, .TRUE., &
                   contribution_cache, prop_sizes(k), &
                   props(sum(prop_sizes(1:k)) - prop_sizes(k) + 1:sum(prop_sizes(1:k))))
              call cpu_time(time_end)

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -232,10 +232,16 @@ module rsp_general
        mem_mgr%max_mat = max_mat
        mem_mgr%remain = max_mat
        mem_mgr%limited = .TRUE.
+       
+       write(*,*) 'mem manager active, total avail', max_mat 
           
     else
        
+       write(*,*) 'mem manager not active'
+       
        mem_mgr%limited = .FALSE.
+       
+       write(*,*) 'then remaining is set to', mem_mgr%remain
           
     end if
     
@@ -920,6 +926,8 @@ module rsp_general
        
     end if
     
+    write(*,*) 'got back from sdf, now remaining mem is', mem_mgr%remain
+    
     ! Check if this stage passed previously and if so, then retrieve and skip execution
     
     call prog_incr(prog_info, r_flag, 1)
@@ -993,6 +1001,8 @@ module rsp_general
 !        call contrib_cache_store(len_cache, contribution_cache, r_flag, 'OPENRSP_CONTRIB_CACHE')
     
     end if
+    
+    write(*,*) 'got back from hf id, now remaining mem is', mem_mgr%remain
 
     ! Check if this stage passed previously and if so, then retrieve and skip execution
     
@@ -1802,11 +1812,13 @@ module rsp_general
        end if
        
        write(out_str, *) 'Outer contribution', k
+       write(*, *) 'Outer contribution', k
        call out_print(out_str, 1)
        
        do i = 1, cache%contribs_outer(m)%num_dmat
        
           write(out_str, *) 'D', cache%contribs_outer(m)%p_tuples(i)%pid
+          write(*, *) 'D', cache%contribs_outer(m)%p_tuples(i)%pid
           call out_print(out_str, 1)
                  
        end do
@@ -1858,6 +1870,7 @@ module rsp_general
     
     end do
     
+    write(*,*) 'outer contract sizes 2', outer_contract_sizes_2
  
     ! Make collapsed contraction sizes array for 1-electron routine call
  
@@ -1920,6 +1933,8 @@ module rsp_general
        return
     
     end if
+    
+    write(*,*) 'mem remain a', mem_mgr%remain
     
     ! Begin memory savings loop 1
     
@@ -2061,7 +2076,7 @@ module rsp_general
        
        call mem_decr(mem_mgr, msize)
        
-       
+       write(*,*) 'mem remain b', mem_mgr%remain
        
     end do
        
@@ -2076,6 +2091,11 @@ module rsp_general
     
        ! Possible to run in non-savings mode
        mem_track = sum(outer_contract_sizes_2(:, 1)) + sum(outer_contract_sizes_2(:, 2))
+       
+       write(*,*) 'can run in non-savings mode', mem_track
+       write(*,*) 'ocs2 1', outer_contract_sizes_2(:, 1)
+       write(*,*) 'ocs2 2', outer_contract_sizes_2(:, 2)
+       
 
     elseif (mem_enough(mem_mgr, 2)) then
 
@@ -2093,7 +2113,7 @@ module rsp_general
     
     end if
     
-    
+    write(*,*) 'mem remain c', mem_mgr%remain
     ! Begin memory savings loop 2
     
     
@@ -2119,6 +2139,8 @@ module rsp_general
        ! improvement here but it is more difficult to make
        
        curr_remain = mem_track
+       
+       write(*,*) 'curr remain is', curr_remain
    
        ! If at start of one outer pair (i.e. not currently in a pair separated into workunits)
        if (.NOT.(intra_pair)) then
@@ -2342,7 +2364,7 @@ module rsp_general
        end if
            
        
-! Not sure about if my ll to array changes work as intended here
+! Not sure if my ll to array changes work as intended here
 ! Next lines are prev version of code kept for reference for potential debugging
 !        k = 1
 !        
@@ -2353,7 +2375,7 @@ module rsp_general
 !        end do
        
        
-
+! DEC 19: CONTINUE HERE
        
        
        lhs_ctr_2 = 1
@@ -2363,54 +2385,79 @@ module rsp_general
 
           ! FIXME: Loop assumes that there is a dummy entry in position 1 of array
           ! Traverse outer elements and fetch matrices
-          do i = curr_pickup(1) + 1, next_pickup(1)
+          
+          write(*,*) 'i to run from', curr_pickup(1), 'to', next_pickup(1) - 1
+          
+          do i = curr_pickup(1), next_pickup(1) - 1
+          
+             write(*,*) 'i is', i
+             write(*,*) 'encountered dummy?', cache%contribs_outer(i + 1)%dummy_entry
 
              if (.NOT.(mem_mgr%calibrate)) then
           
                 ! No chain rule applications
-                if (cache%contribs_outer(i)%num_dmat == 0) then
+                if (cache%contribs_outer(i + 1)%num_dmat == 0) then
            
                    call contrib_cache_getdata_outer(size(D), D, 1, (/get_emptypert()/), .FALSE., &
                         1, ind_len=1, ind_unsorted=(/1/), mat_sing=LHS_dmat_2(lhs_ctr_2))
                    call contrib_cache_getdata_outer(size(D), D, 1, (/get_emptypert()/), .FALSE., &
                         1, ind_len=1, ind_unsorted=(/1/), mat_sing=RHS_dmat_2(rhs_ctr_2))
+                        
+                   write(*,*) '0cr asking to put lh mat sing elem', lhs_ctr_2
+                   write(*,*) '0cr size of lhs dmat 2', size(LHS_dmat_2)     
+                   write(*,*) '0cr asking to put rh mat sing elem', rhs_ctr_2
+                   write(*,*) '0cr size of rhs dmat 2', size(RHS_dmat_2)
    
                 ! One chain rule application
-                else if (cache%contribs_outer(i)%num_dmat == 1) then
+                else if (cache%contribs_outer(i + 1)%num_dmat == 1) then
           
                    do m = 1, outer_contract_sizes_2(i, 1) 
+                   
+                      write(*,*) '1cr asking to put lh mat sing elem', lhs_ctr_2 + m  - 1
+                      write(*,*) '1cr size of lhs dmat 2', size(LHS_dmat_2)
+                   
                       call contrib_cache_getdata_outer(size(D), D, 1, &
-                           (/cache%contribs_outer(i)%p_tuples(1)/), .FALSE., &
-                           1, ind_len=size(cache%contribs_outer(i)%indices, 2), &
-                           ind_unsorted=cache%contribs_outer(i)%indices(m, :), &
+                           (/cache%contribs_outer(i + 1)%p_tuples(1)/), .FALSE., &
+                           1, ind_len=size(cache%contribs_outer(i + 1)%indices, 2), &
+                           ind_unsorted=cache%contribs_outer(i + 1)%indices(m, :), &
                            mat_sing=LHS_dmat_2(lhs_ctr_2 + m  - 1))
                    end do
+                   
+                   write(*,*) '1cr asking to put rh mat sing elem', rhs_ctr_2
+                   write(*,*) '1cr size of rhs dmat 2', size(RHS_dmat_2)
              
                    call contrib_cache_getdata_outer(size(D), D, 1, (/get_emptypert()/), .FALSE., &
                         1, ind_len=1, ind_unsorted=(/1/), mat_sing=RHS_dmat_2(rhs_ctr_2))
           
                 ! Two chain rule applications
-                else if (cache%contribs_outer(i)%num_dmat == 2) then
+                else if (cache%contribs_outer(i + 1)%num_dmat == 2) then
             
                    do m = 1, outer_contract_sizes_2(i, 1) 
+                   
+                      write(*,*) '2cr asking to put lh mat sing elem', lhs_ctr_2 + m  - 1
+                      write(*,*) '2cr size of lhs dmat 2', size(LHS_dmat_2)
               
-                      call contrib_cache_getdata_outer(size(D), D, 1, (/cache%contribs_outer(i)%p_tuples(1)/), .FALSE., &
-                           1, ind_len=cache%contribs_outer(i)%p_tuples(1)%npert, &
-                           ind_unsorted=cache%contribs_outer(i)%indices(1 + &
-                           (m - 1) * cache%contribs_outer(i)%blks_tuple_triang_size(2), &
-                           1:cache%contribs_outer(i)%p_tuples(1)%npert), &
+                      call contrib_cache_getdata_outer(size(D), D, 1, &
+                           (/cache%contribs_outer(i + 1)%p_tuples(1)/), .FALSE., &
+                           1, ind_len=cache%contribs_outer(i + 1)%p_tuples(1)%npert, &
+                           ind_unsorted=cache%contribs_outer(i + 1)%indices(1 + &
+                           (m - 1) * cache%contribs_outer(i + 1)%blks_tuple_triang_size(2), &
+                           1:cache%contribs_outer(i + 1)%p_tuples(1)%npert), &
                            mat_sing=LHS_dmat_2(lhs_ctr_2 + m  - 1))
                    end do
              
                    do n = 1, outer_contract_sizes_2(i, 2) 
+                   
+                      write(*,*) '2cr asking to put rh mat sing elem', rhs_ctr_2 + n  - 1
+                      write(*,*) '2cr size of rhs dmat 2', size(RHS_dmat_2)
              
                       call contrib_cache_getdata_outer(size(D), D, 1, &
-                      (/cache%contribs_outer(i)%p_tuples(2)/), .FALSE., &
-                           1, ind_len=cache%contribs_outer(i)%p_tuples(2)%npert, &
-                           ind_unsorted=cache%contribs_outer(i)%indices(n, &
-                           cache%contribs_outer(i)%p_tuples(1)%npert + 1: &
-                           cache%contribs_outer(i)%p_tuples(1)%npert + &
-                           cache%contribs_outer(i)%p_tuples(2)%npert), &
+                      (/cache%contribs_outer(i + 1)%p_tuples(2)/), .FALSE., &
+                           1, ind_len=cache%contribs_outer(i + 1)%p_tuples(2)%npert, &
+                           ind_unsorted=cache%contribs_outer(i + 1)%indices(n, &
+                           cache%contribs_outer(i + 1)%p_tuples(1)%npert + 1: &
+                           cache%contribs_outer(i + 1)%p_tuples(1)%npert + &
+                           cache%contribs_outer(i + 1)%p_tuples(2)%npert), &
                            mat_sing=RHS_dmat_2(rhs_ctr_2 + n  - 1))
                    end do          
           

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -233,16 +233,10 @@ module rsp_general
        mem_mgr%remain = max_mat
        mem_mgr%limited = .TRUE.
        
-       write(*,*) 'mem manager active, total avail', max_mat 
-          
     else
-       
-       write(*,*) 'mem manager not active'
        
        mem_mgr%limited = .FALSE.
        
-       write(*,*) 'then remaining is set to', mem_mgr%remain
-          
     end if
     
     
@@ -926,8 +920,6 @@ module rsp_general
        
     end if
     
-    write(*,*) 'got back from sdf, now remaining mem is', mem_mgr%remain
-    
     ! Check if this stage passed previously and if so, then retrieve and skip execution
     
     call prog_incr(prog_info, r_flag, 1)
@@ -1002,8 +994,6 @@ module rsp_general
     
     end if
     
-    write(*,*) 'got back from hf id, now remaining mem is', mem_mgr%remain
-
     ! Check if this stage passed previously and if so, then retrieve and skip execution
     
     call prog_incr(prog_info, r_flag, 1)
@@ -1812,13 +1802,11 @@ module rsp_general
        end if
        
        write(out_str, *) 'Outer contribution', k
-       write(*, *) 'Outer contribution', k
        call out_print(out_str, 1)
        
        do i = 1, cache%contribs_outer(m)%num_dmat
        
           write(out_str, *) 'D', cache%contribs_outer(m)%p_tuples(i)%pid
-          write(*, *) 'D', cache%contribs_outer(m)%p_tuples(i)%pid
           call out_print(out_str, 1)
                  
        end do
@@ -1870,8 +1858,6 @@ module rsp_general
     
     end do
     
-    write(*,*) 'outer contract sizes 2', outer_contract_sizes_2
- 
     ! Make collapsed contraction sizes array for 1-electron routine call
  
     allocate(outer_contract_sizes_1_coll(num_1))
@@ -1933,8 +1919,6 @@ module rsp_general
        return
     
     end if
-    
-    write(*,*) 'mem remain a', mem_mgr%remain
     
     ! Begin memory savings loop 1
     
@@ -2076,8 +2060,6 @@ module rsp_general
        
        call mem_decr(mem_mgr, msize)
        
-       write(*,*) 'mem remain b', mem_mgr%remain
-       
     end do
        
     ! End memory savings loop 1
@@ -2092,11 +2074,6 @@ module rsp_general
        ! Possible to run in non-savings mode
        mem_track = sum(outer_contract_sizes_2(:, 1)) + sum(outer_contract_sizes_2(:, 2))
        
-       write(*,*) 'can run in non-savings mode', mem_track
-       write(*,*) 'ocs2 1', outer_contract_sizes_2(:, 1)
-       write(*,*) 'ocs2 2', outer_contract_sizes_2(:, 2)
-       
-
     elseif (mem_enough(mem_mgr, 2)) then
 
        ! Possible to run in savings mode
@@ -2113,7 +2090,6 @@ module rsp_general
     
     end if
     
-    write(*,*) 'mem remain c', mem_mgr%remain
     ! Begin memory savings loop 2
     
     
@@ -2140,8 +2116,6 @@ module rsp_general
        
        curr_remain = mem_track
        
-       write(*,*) 'curr remain is', curr_remain
-   
        ! If at start of one outer pair (i.e. not currently in a pair separated into workunits)
        if (.NOT.(intra_pair)) then
        
@@ -2386,12 +2360,7 @@ module rsp_general
           ! FIXME: Loop assumes that there is a dummy entry in position 1 of array
           ! Traverse outer elements and fetch matrices
           
-          write(*,*) 'i to run from', curr_pickup(1), 'to', next_pickup(1) - 1
-          
           do i = curr_pickup(1), next_pickup(1) - 1
-          
-             write(*,*) 'i is', i
-             write(*,*) 'encountered dummy?', cache%contribs_outer(i + 1)%dummy_entry
 
              if (.NOT.(mem_mgr%calibrate)) then
           
@@ -2403,18 +2372,10 @@ module rsp_general
                    call contrib_cache_getdata_outer(size(D), D, 1, (/get_emptypert()/), .FALSE., &
                         1, ind_len=1, ind_unsorted=(/1/), mat_sing=RHS_dmat_2(rhs_ctr_2))
                         
-                   write(*,*) '0cr asking to put lh mat sing elem', lhs_ctr_2
-                   write(*,*) '0cr size of lhs dmat 2', size(LHS_dmat_2)     
-                   write(*,*) '0cr asking to put rh mat sing elem', rhs_ctr_2
-                   write(*,*) '0cr size of rhs dmat 2', size(RHS_dmat_2)
-   
                 ! One chain rule application
                 else if (cache%contribs_outer(i + 1)%num_dmat == 1) then
           
                    do m = 1, outer_contract_sizes_2(i, 1) 
-                   
-                      write(*,*) '1cr asking to put lh mat sing elem', lhs_ctr_2 + m  - 1
-                      write(*,*) '1cr size of lhs dmat 2', size(LHS_dmat_2)
                    
                       call contrib_cache_getdata_outer(size(D), D, 1, &
                            (/cache%contribs_outer(i + 1)%p_tuples(1)/), .FALSE., &
@@ -2422,9 +2383,6 @@ module rsp_general
                            ind_unsorted=cache%contribs_outer(i + 1)%indices(m, :), &
                            mat_sing=LHS_dmat_2(lhs_ctr_2 + m  - 1))
                    end do
-                   
-                   write(*,*) '1cr asking to put rh mat sing elem', rhs_ctr_2
-                   write(*,*) '1cr size of rhs dmat 2', size(RHS_dmat_2)
              
                    call contrib_cache_getdata_outer(size(D), D, 1, (/get_emptypert()/), .FALSE., &
                         1, ind_len=1, ind_unsorted=(/1/), mat_sing=RHS_dmat_2(rhs_ctr_2))
@@ -2433,9 +2391,6 @@ module rsp_general
                 else if (cache%contribs_outer(i + 1)%num_dmat == 2) then
             
                    do m = 1, outer_contract_sizes_2(i, 1) 
-                   
-                      write(*,*) '2cr asking to put lh mat sing elem', lhs_ctr_2 + m  - 1
-                      write(*,*) '2cr size of lhs dmat 2', size(LHS_dmat_2)
               
                       call contrib_cache_getdata_outer(size(D), D, 1, &
                            (/cache%contribs_outer(i + 1)%p_tuples(1)/), .FALSE., &
@@ -2447,9 +2402,6 @@ module rsp_general
                    end do
              
                    do n = 1, outer_contract_sizes_2(i, 2) 
-                   
-                      write(*,*) '2cr asking to put rh mat sing elem', rhs_ctr_2 + n  - 1
-                      write(*,*) '2cr size of rhs dmat 2', size(RHS_dmat_2)
              
                       call contrib_cache_getdata_outer(size(D), D, 1, &
                       (/cache%contribs_outer(i + 1)%p_tuples(2)/), .FALSE., &

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -773,6 +773,8 @@ module rsp_general
                 if (abs(real(rsp_tensor(p + n))) >= write_threshold) then
                 
                    allocate(arg_ind(size(indices(n,:))))
+                   
+                   arg_ind = indices(n, :)
 
                    write(260,*) arg_ind
 
@@ -4017,6 +4019,9 @@ module rsp_general
 
                    allocate(arg_int_d(size((/cache%indices(j, :), &
                         cache%contribs_outer(m)%indices(i, :)/))))
+                        
+                   arg_int_d = (/cache%indices(j, :), &
+                        cache%contribs_outer(m)%indices(i, :)/)
 
                    offset = get_triang_blks_tuple_offset(2, tot_num_pert, &
                    arg_int, arg_int_b, &
@@ -4042,6 +4047,8 @@ module rsp_general
              end if
                 
              if (cache%contribs_outer(m)%contrib_type == 1) then
+                
+                write(*,*) 'my offset is', offset
                 
                 cache%contribs_outer(m)%data_scal(offset) = contrib_pulay(j + &
                 size(cache%indices, 1) * (i - 1) + o_ctr)

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -161,7 +161,7 @@ module rsp_general
     complex(8), dimension(rsp_tensor_size) :: rsp_tensor
     type(QcMat) :: S_unpert, D_unpert, F_unpert ! NOTE: Make optional to exclude in mem. calibration mode
 
-    type(contrib_cache_outer) :: S, D, F, Xf
+    type(contrib_cache_outer), allocatable, dimension(:) :: S, D, F, Xf
     integer :: kn(2)
     character(30) :: fmt_str
     real, parameter :: xtiny=1.0d-8

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -4193,6 +4193,8 @@ module rsp_general
                      size(cache%indices(mcurr + i - 1,:)), arg_int, &
                      size(D), D, size(S), S, Lambda(i), select_terms_arg = select_terms)
       
+                deallocate(arg_int)
+      
              end do
              
           end if

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -2482,8 +2482,6 @@ module rsp_general
 
                       ind_uns = cache%contribs_outer(i + 1)%indices(m, :)
                     
-                    write(*,*) 'asking for ind uns', ind_uns
-                   
                       call contrib_cache_getdata_outer(size(D), D, 1, &
                            arg_tuple, .FALSE., &
                            1, ind_len=size(cache%contribs_outer(i + 1)%indices, 2), &
@@ -2522,9 +2520,6 @@ module rsp_general
                            (m - 1) * cache%contribs_outer(i + 1)%blks_tuple_triang_size(2), &
                            1:cache%contribs_outer(i + 1)%p_tuples(1)%npert)
                            
-                           write(*,*) 'my left ind uns', ind_uns
-                           write(*,*) 'it goes into lhs ind', lhs_ctr_2 + m  - 1
-
                       call contrib_cache_getdata_outer(size(D), D, 1, &
                            arg_tuple, .FALSE., &
                            1, ind_len=cache%contribs_outer(i + 1)%p_tuples(1)%npert, &
@@ -2553,9 +2548,6 @@ module rsp_general
                            cache%contribs_outer(i + 1)%p_tuples(1)%npert + &
                            cache%contribs_outer(i + 1)%p_tuples(2)%npert)
                            
-                           write(*,*) 'my right ind uns', ind_uns
-                            write(*,*) 'it goes into rhs ind', rhs_ctr_2 + n  - 1
-
                       call contrib_cache_getdata_outer(size(D), D, 1, &
                            arg_tuple, .FALSE., &
                            1, ind_len=cache%contribs_outer(i + 1)%p_tuples(2)%npert, &
@@ -2957,10 +2949,10 @@ module rsp_general
                       deallocate(arg_int_b)
                       deallocate(arg_int)
 
-                       write(*,*) 'Index tuple:', (/cache%indices(j, :), cache%contribs_outer(m)%indices(i, :)/)
-                       write(*,*) 'Saving element', j + size(cache%indices, 1) * (i - 1), &
-                       'of data in cache element', offset
-                       write(*,*) 'data is',  data_tmp(j + size(cache%indices, 1) * (i - 1))
+!                        write(*,*) 'Index tuple:', (/cache%indices(j, :), cache%contribs_outer(m)%indices(i, :)/)
+!                        write(*,*) 'Saving element', j + size(cache%indices, 1) * (i - 1), &
+!                        'of data in cache element', offset
+!                        write(*,*) 'data is',  data_tmp(j + size(cache%indices, 1) * (i - 1))
                    
                       cache%contribs_outer(m)%data_scal(offset) = data_tmp(j + &
                       size(cache%indices, 1) * (i - 1))
@@ -4058,8 +4050,6 @@ module rsp_general
              end if
                 
              if (cache%contribs_outer(m)%contrib_type == 1) then
-                
-                write(*,*) 'my offset is', offset
                 
                 cache%contribs_outer(m)%data_scal(offset) = contrib_pulay(j + &
                 size(cache%indices, 1) * (i - 1) + o_ctr)

--- a/src/ao_dens/rsp_indices_and_addressing.f90
+++ b/src/ao_dens/rsp_indices_and_addressing.f90
@@ -438,8 +438,11 @@ module rsp_indices_and_addressing
     type(QcMat) :: A, B
     integer(kind=4) :: ierr
     real(8) :: k
+    real(8), dimension(2) :: karr
+
+    karr = (/k, 0.0d0/)
     
-    ierr = QcMatAXPY_f((/k, 0.0d0/), A, B)
+    ierr = QcMatAXPY_f(karr, A, B)
   
   end subroutine
   

--- a/src/ao_dens/rsp_indices_and_addressing.f90
+++ b/src/ao_dens/rsp_indices_and_addressing.f90
@@ -333,14 +333,19 @@ module rsp_indices_and_addressing
     type(QcMat) T
     integer(kind=4) :: ierr
     complex(8) :: k
-        
+    real(8), dimension(2) :: n1, n2, n3
+
+    n1 = (/dreal(k), dimag(k)/)
+    n2 = (/0.0d0, 0.0d0/)
+    n3 = (/1.0d0, 0.0d0/)
+
     call QcMatInit(T, A)
 
     ! T = kB * C
-    ierr = QcMatGEMM_f(MAT_NO_OPERATION, MAT_NO_OPERATION, (/dreal(k), dimag(k)/), B, C, (/0.0d0, 0.0d0/), T)
+    ierr = QcMatGEMM_f(MAT_NO_OPERATION, MAT_NO_OPERATION, n1, B, C, n2, T)
     
     ! R = A * T
-    ierr = QcMatGEMM_f(MAT_NO_OPERATION, MAT_NO_OPERATION, (/1.0d0, 0.0d0/), A, T, (/0.0d0, 0.0d0/), R)
+    ierr = QcMatGEMM_f(MAT_NO_OPERATION, MAT_NO_OPERATION, n3, A, T, n2, R)
     ierr = QcMatDestroy_f(T)
 
   end subroutine
@@ -353,14 +358,19 @@ module rsp_indices_and_addressing
     type(QcMat) :: A, B, C, R
     type(QcMat) T
     integer(kind=4) :: ierr
-    integer :: i
+
+    real(8), dimension(2) :: n1, n2, n3
     real(8) :: k
-        
+
+    n1 = (/k, 0.0d0/)
+    n2 = (/0.0d0, 0.0d0/)
+    n3 = (/1.0d0, 0.0d0/)
+
     call QcMatInit(T, A)
-    
-    ierr = QcMatGEMM_f(MAT_NO_OPERATION, MAT_NO_OPERATION, (/k, 0.0d0/), B, C, (/0.0d0, 0.0d0/), T)
-    ierr = QcMatGEMM_f(MAT_NO_OPERATION, MAT_NO_OPERATION, (/1.0d0, 0.0d0/), A, T, (/0.0d0, 0.0d0/), R)
-    
+
+    ierr = QcMatGEMM_f(MAT_NO_OPERATION, MAT_NO_OPERATION, n1, B, C, n2, T)
+    ierr = QcMatGEMM_f(MAT_NO_OPERATION, MAT_NO_OPERATION, n3, A, T, n2, R)
+
     ierr = QcMatDestroy_f(T)
   
   end subroutine
@@ -705,9 +715,9 @@ module rsp_indices_and_addressing
        blk_arg_ii = blks_info(i, 1:nblks_tuple(i), :)
 
        offset = offset + (get_triang_blks_offset(nblks_tuple(i), nfields(i), &
-                         blks_info(i,1:nblks_tuple(i),:), &
-                         blk_sizes(i, 1:nblks_tuple(i)),  &
-                         inds(k:k + nfields(i) - 1))  - 1 )* &
+                         blk_arg_ii, &
+                         blk_arg_i,  &
+                         blk_arg_i_b)  - 1 )* &
                          (product(blks_sizes(i:ntuple))/blks_sizes(i))
        k = k + nfields(i)
 

--- a/src/ao_dens/rsp_indices_and_addressing.f90
+++ b/src/ao_dens/rsp_indices_and_addressing.f90
@@ -314,9 +314,12 @@ module rsp_indices_and_addressing
     type(QcMat) :: A, B, R
     integer(kind=4) :: ierr
     real(8) :: k
+    real(8), dimension(2) :: karr
+
+    karr = (/k, 0.0d0/)
     
-    ierr = QcMatAXPY_f((/k, 0.0d0/), B, A)
-    ierr = QcMatAXPY_f((/k, 0.0d0/), A, R)
+    ierr = QcMatAXPY_f(karr, B, A)
+    ierr = QcMatAXPY_f(karr, A, R)
     
   end subroutine
   
@@ -681,11 +684,22 @@ module rsp_indices_and_addressing
     integer, dimension(ntuple, total_num_perturbations, 3) :: blks_info
     integer, dimension(ntuple, total_num_perturbations) :: blk_sizes
     integer, dimension(sum(nfields)) :: inds
+    integer, allocatable, dimension(:) :: blk_arg_i, blk_arg_i_b
+    integer, allocatable, dimension(:, :) :: blk_arg_ii
     
     offset = 0
     k = 1
     
     do i = 1, ntuple - 1
+
+       ! Prepared, change when covered
+       allocate(blk_arg_i(nblks_tuple(i)))
+       allocate(blk_arg_i_b(nfields(i)))
+       allocate(blk_arg_ii(nblks_tuple(i), size(blks_info, 3)))
+      
+       blk_arg_i = blk_sizes(i, 1:nblks_tuple(i))
+       blk_arg_i_b = inds(k:k + nfields(i) - 1)
+       blk_arg_ii = blks_info(i, 1:nblks_tuple(i), :)
 
        offset = offset + (get_triang_blks_offset(nblks_tuple(i), nfields(i), &
                          blks_info(i,1:nblks_tuple(i),:), &
@@ -694,12 +708,33 @@ module rsp_indices_and_addressing
                          (product(blks_sizes(i:ntuple))/blks_sizes(i))
        k = k + nfields(i)
 
+       deallocate(blk_arg_ii)
+       deallocate(blk_arg_i_b)
+       deallocate(blk_arg_i)
+
     end do
+
+    allocate(blk_arg_i(nblks_tuple(ntuple)))
+    allocate(blk_arg_i_b(nfields(ntuple)))
+    allocate(blk_arg_ii(nblks_tuple(ntuple), size(blks_info, 3)))
+      
+    blk_arg_i = blk_sizes(ntuple, 1:nblks_tuple(ntuple))
+    blk_arg_i_b = inds(k:k + nfields(ntuple) - 1)
+    blk_arg_ii = blks_info(ntuple, 1:nblks_tuple(ntuple), :)
     
     offset = offset + get_triang_blks_offset(nblks_tuple(ntuple), nfields(ntuple), &
-                      blks_info(ntuple,1:nblks_tuple(ntuple),:), &
-                      blk_sizes(ntuple, 1:nblks_tuple(ntuple)),  &
-                      inds(k:k + nfields(ntuple) - 1))
+                      blk_arg_ii, & 
+                      blk_arg_i, &
+                      blk_arg_i_b)
+
+!    offset = offset + get_triang_blks_offset(nblks_tuple(ntuple), nfields(ntuple), &
+!                      blks_info(ntuple,1:nblks_tuple(ntuple),:), &
+!                      blk_sizes(ntuple, 1:nblks_tuple(ntuple)),  &
+!                      inds(k:k + nfields(ntuple) - 1))
+
+    deallocate(blk_arg_ii)
+    deallocate(blk_arg_i_b)
+    deallocate(blk_arg_i)
                       
   end function
 
@@ -891,6 +926,7 @@ module rsp_indices_and_addressing
     integer, dimension(ntuples, total_num_perturbations, 3) :: blks_tuple_info
     integer, dimension(product(blks_tuple_triang_size), & 
              total_num_perturbations) :: indices
+    integer, allocatable, dimension(:,:) :: blks_info_call
     type(triangulated_index_block), allocatable, &
          dimension(:) :: individual_block_tuple_indices
 
@@ -901,9 +937,16 @@ module rsp_indices_and_addressing
        allocate(individual_block_tuple_indices(i)%t_ind(blks_tuple_triang_size(i), &
                 sum(blks_tuple_info(i,1:nblks_tuple(i),2))))
 
+       allocate(blks_info_call(nblks_tuple(i), &
+       size(blks_tuple_info,3)))
+
+       blks_info_call = blks_tuple_info(i,1:nblks_tuple(i),:)
+
        call make_triangulated_indices(nblks_tuple(i), &
-            blks_tuple_info(i,1:nblks_tuple(i),:), blks_tuple_triang_size(i), &
+            blks_info_call, blks_tuple_triang_size(i), &
             individual_block_tuple_indices(i)%t_ind)
+
+       deallocate(blks_info_call)
 
     end do
 

--- a/src/ao_dens/rsp_perturbed_matrices.f90
+++ b/src/ao_dens/rsp_perturbed_matrices.f90
@@ -47,7 +47,7 @@ module rsp_perturbed_matrices
 
     logical :: primed
     type(p_tuple) :: pert
-    type(p_tuple), dimension(3) :: current_derivative_term
+    type(p_tuple), dimension(3) :: current_derivative_term, next_deriv_term
     integer, dimension(2) :: kn
     integer :: i, superstructure_size
 
@@ -56,22 +56,25 @@ module rsp_perturbed_matrices
     ! Recurse
     if (pert%npert > 0) then
 
-       superstructure_size = superstructure_size + derivative_superstructure_getsize( &
-                             p_tuple_remove_first(pert), kn, primed, &
-                             (/p_tuple_extend(current_derivative_term(1), &
-                             p_tuple_getone(pert, 1)), current_derivative_term(2:3)/))
+       next_deriv_term = (/p_tuple_extend(current_derivative_term(1), &
+                             p_tuple_getone(pert, 1)), current_derivative_term(2:3)/)
 
        superstructure_size = superstructure_size + derivative_superstructure_getsize( &
-                             p_tuple_remove_first(pert), kn, primed, &
-                             (/current_derivative_term(1), &
+                             p_tuple_remove_first(pert), kn, primed, next_deriv_term)
+
+       next_deriv_term = (/current_derivative_term(1), &
                              p_tuple_extend(current_derivative_term(2), &
-                             p_tuple_getone(pert,1)), current_derivative_term(3)/))
+                             p_tuple_getone(pert,1)), current_derivative_term(3)/)
 
        superstructure_size = superstructure_size + derivative_superstructure_getsize( &
-                             p_tuple_remove_first(pert), kn, primed, &
-                             (/current_derivative_term(1:2), &
+                             p_tuple_remove_first(pert), kn, primed, next_deriv_term)
+
+       next_deriv_term = (/current_derivative_term(1:2), &
                              p_tuple_extend(current_derivative_term(3), &
-                             p_tuple_getone(pert, 1))/))
+                             p_tuple_getone(pert, 1))/)
+
+       superstructure_size = superstructure_size + derivative_superstructure_getsize( &
+                             p_tuple_remove_first(pert), kn, primed, next_deriv_term)
 
     ! End of recursion: Determine if term is kept and if so, increment counter
     else
@@ -122,30 +125,42 @@ module rsp_perturbed_matrices
     integer :: i, superstructure_size, new_element_position
     integer, dimension(2) :: kn    
     type(p_tuple) :: pert
-    type(p_tuple), dimension(3) :: current_derivative_term
+    type(p_tuple), dimension(3) :: current_derivative_term, next_deriv_term
     type(p_tuple), dimension(superstructure_size, 3) :: derivative_structure
 
     ! Recurse
     if (pert%npert > 0) then
 
+       next_deriv_term = (/p_tuple_extend(current_derivative_term(1), &
+                           p_tuple_getone(pert, 1)), current_derivative_term(2:3)/)
+
+
        call derivative_superstructure(p_tuple_remove_first(pert), kn, primed, &
-            (/p_tuple_extend(current_derivative_term(1), p_tuple_getone(pert, 1)), &
-            current_derivative_term(2:3)/), superstructure_size, new_element_position, &
+            next_deriv_term, superstructure_size, new_element_position, &
             derivative_structure)
 
-       call derivative_superstructure(p_tuple_remove_first(pert), kn, primed, &
-            (/current_derivative_term(1), p_tuple_extend(current_derivative_term(2), &
-            p_tuple_getone(pert, 1)), current_derivative_term(3)/), &
-            superstructure_size, new_element_position, derivative_structure)
+       next_deriv_term = (/current_derivative_term(1), &
+                             p_tuple_extend(current_derivative_term(2), &
+                             p_tuple_getone(pert,1)), current_derivative_term(3)/)
+
 
        call derivative_superstructure(p_tuple_remove_first(pert), kn, primed, &
-            (/current_derivative_term(1:2), p_tuple_extend(current_derivative_term(3), &
-            p_tuple_getone(pert, 1))/), superstructure_size, new_element_position, &
+            next_deriv_term, &
+            superstructure_size, new_element_position, derivative_structure)
+
+       next_deriv_term = (/current_derivative_term(1:2), &
+                             p_tuple_extend(current_derivative_term(3), &
+                             p_tuple_getone(pert, 1))/)
+
+
+       call derivative_superstructure(p_tuple_remove_first(pert), kn, primed, &
+            next_deriv_term, superstructure_size, new_element_position, &
             derivative_structure)
 
     ! End of recursion: Determine if term is kept and if so, store the superstructure element
     else
 
+       next_deriv_term = current_derivative_term
 
        if (primed .EQV. .TRUE.) then
 
@@ -154,7 +169,7 @@ module rsp_perturbed_matrices
               current_derivative_term(3)%npert <= kn(2) ) .eqv. .TRUE.) then
 
              new_element_position = new_element_position + 1
-             derivative_structure(new_element_position, :) = current_derivative_term
+             derivative_structure(new_element_position, :) = next_deriv_term
  
           end if
 
@@ -168,7 +183,7 @@ module rsp_perturbed_matrices
                           current_derivative_term(3)%pid, kn) ) .eqv. .FALSE.) then
 
              new_element_position = new_element_position + 1 
-             derivative_structure(new_element_position, :) = current_derivative_term(:)
+             derivative_structure(new_element_position, :) = next_deriv_term(:)
 
           end if
 
@@ -190,6 +205,8 @@ module rsp_perturbed_matrices
     type(p_tuple), dimension(superstructure_size, 3) :: deriv_struct
     integer, dimension(total_num_perturbations) :: which_index_is_pid
     integer, dimension(indices_len) :: ind
+    type(p_tuple), dimension(1) :: ds1, ds2, ds3
+    integer, dimension(:), allocatable :: iu1, iu2, iu3
     integer :: len_f, len_d, len_s
     type(contrib_cache_outer), dimension(len_f) :: F
     type(contrib_cache_outer), dimension(len_d) :: D
@@ -205,15 +222,27 @@ module rsp_perturbed_matrices
     
     do i = 1, superstructure_size
 
-       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-       call contrib_cache_getdata_outer(len_f, F, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)                
-       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)       
+       ds1(1) = deriv_struct(i,1)
+       ds2(1) = deriv_struct(i,2)
+       ds3(1) = deriv_struct(i,3)
+
+       allocate(iu1(ds1(1)%npert))
+       allocate(iu2(ds2(1)%npert))
+       allocate(iu3(ds3(1)%npert))
+
+       iu1 = get_fds_data_index(ds1(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+       iu2 = get_fds_data_index(ds2(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+       iu3 = get_fds_data_index(ds3(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+
+       call contrib_cache_getdata_outer(len_d, D, 1, ds1, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu1, mat_sing=A) 
+       call contrib_cache_getdata_outer(len_f, F, 1, ds2, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu2, mat_sing=B)                
+       call contrib_cache_getdata_outer(len_d, D, 1, ds3, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu3, mat_sing=C)       
 
 !      W = W + A * B * C
        call QcMatkABC(1.0d0, A, B, C, T)
@@ -226,15 +255,12 @@ module rsp_perturbed_matrices
          if (.not.(frequency_zero_or_sum(deriv_struct(i,1)) == 0.0) .and. &
              .not.(frequency_zero_or_sum(deriv_struct(i,3)) == 0.0)) then
 
-          call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)                
-          call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)               
+          call contrib_cache_getdata_outer(len_d, D, 1, ds1, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu1, mat_sing=A) 
+          call contrib_cache_getdata_outer(len_s, S, 1, ds2, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu2, mat_sing=B)                
+          call contrib_cache_getdata_outer(len_d, D, 1, ds3, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu3, mat_sing=C)               
                
 
 !            W = W + ((1.0)/(2.0)) * (frequency_zero_or_sum(deriv_struct(i,1)) - &
@@ -248,15 +274,12 @@ module rsp_perturbed_matrices
          elseif (.not.(frequency_zero_or_sum(deriv_struct(i,1)) == 0.0) .and. &
                       (frequency_zero_or_sum(deriv_struct(i,3)) == 0.0)) then
 
-          call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)                
-          call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)               
+          call contrib_cache_getdata_outer(len_d, D, 1, ds1, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu1, mat_sing=A) 
+          call contrib_cache_getdata_outer(len_s, S, 1, ds2, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu2, mat_sing=B)                
+          call contrib_cache_getdata_outer(len_d, D, 1, ds3, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu3, mat_sing=C)               
 
 !           W = W + ((1.0)/(2.0)) * frequency_zero_or_sum(deriv_struct(i,1)) * A * B * C
                
@@ -268,15 +291,12 @@ module rsp_perturbed_matrices
          elseif (.not.(frequency_zero_or_sum(deriv_struct(i,3)) == 0.0) .and. &
                       (frequency_zero_or_sum(deriv_struct(i,1)) == 0.0)) then
                
-          call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)                
-          call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)                
+          call contrib_cache_getdata_outer(len_d, D, 1, ds1, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu1, mat_sing=A) 
+          call contrib_cache_getdata_outer(len_s, S, 1, ds2, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu2, mat_sing=B)                
+          call contrib_cache_getdata_outer(len_d, D, 1, ds3, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu3, mat_sing=C)                
 
 !           W = W + ((-1.0)/(2.0)) * frequency_zero_or_sum(deriv_struct(i,3))  * A * B * C
 
@@ -285,6 +305,11 @@ module rsp_perturbed_matrices
           
          end if
        end if
+
+       deallocate(iu1)
+       deallocate(iu2)
+       deallocate(iu3)
+
 
     end do
 
@@ -307,6 +332,8 @@ module rsp_perturbed_matrices
     integer :: i, total_num_perturbations, superstructure_size, indices_len, j
     type(p_tuple), dimension(superstructure_size, 3) :: deriv_struct
     integer, dimension(total_num_perturbations) :: which_index_is_pid
+    type(p_tuple), dimension(1) :: ds1, ds2, ds3
+    integer, dimension(:), allocatable :: iu1, iu2, iu3
     integer, dimension(indices_len) :: ind
     integer :: len_f, len_d, len_s
     type(contrib_cache_outer), dimension(len_f) :: F
@@ -337,15 +364,29 @@ module rsp_perturbed_matrices
          calc_contrib = .not.find_residue_info(deriv_struct(i,3))
        end if
 
-       call contrib_cache_getdata_outer(len_f, F, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)             
-       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)             
-       call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C) 
+       ds1(1) = deriv_struct(i,1)
+       ds2(1) = deriv_struct(i,2)
+       ds3(1) = deriv_struct(i,3)
+
+       allocate(iu1(ds1(1)%npert))
+       allocate(iu2(ds2(1)%npert))
+       allocate(iu3(ds3(1)%npert))
+
+       iu1 = get_fds_data_index(ds1(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+       iu2 = get_fds_data_index(ds2(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+       iu3 = get_fds_data_index(ds3(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+
+
+
+       call contrib_cache_getdata_outer(len_f, F, 1, ds1, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu1, mat_sing=A)             
+       call contrib_cache_getdata_outer(len_d, D, 1, ds2, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu2, mat_sing=B)             
+       call contrib_cache_getdata_outer(len_s, S, 1, ds3, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu3, mat_sing=C) 
 
 !        Y = Y + A*B*C
        if (calc_contrib) then
@@ -360,9 +401,8 @@ module rsp_perturbed_matrices
           else
             calc_contrib = .not.(find_residue_info(deriv_struct(i,1)).or.find_residue_info(deriv_struct(i,3)))
           end if
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)
+          call contrib_cache_getdata_outer(len_s, S, 1, ds1, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu1, mat_sing=A)
 
 !           Y = Y - frequency_zero_or_sum(deriv_struct(i,2)) * A * B * C
 
@@ -378,12 +418,10 @@ module rsp_perturbed_matrices
        else 
           calc_contrib = .not.find_residue_info(deriv_struct(i,1))
        end if
-       call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)  
-       call contrib_cache_getdata_outer(len_f, F, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)  
+       call contrib_cache_getdata_outer(len_s, S, 1, ds1, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu1, mat_sing=A)  
+       call contrib_cache_getdata_outer(len_f, F, 1, ds3, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu3, mat_sing=C)  
                        
 
 !        Y = Y - A * B * C
@@ -402,12 +440,10 @@ module rsp_perturbed_matrices
           ! MaR: MAKE SURE THAT THESE (AND B) ARE ACTUALLY THE CORRECT 
           ! MATRICES TO USE HERE AND BELOW
 
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)  
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)  
+          call contrib_cache_getdata_outer(len_s, S, 1, ds1, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu1, mat_sing=A)  
+          call contrib_cache_getdata_outer(len_s, S, 1, ds3, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu3, mat_sing=C)  
        
                
 !           Y = Y + ((-1.0)/(2.0)) * (frequency_zero_or_sum(deriv_struct(i,1)) + &
@@ -422,12 +458,10 @@ module rsp_perturbed_matrices
        elseif (.not.(frequency_zero_or_sum(deriv_struct(i,1)) == 0.0) .and. &
              (frequency_zero_or_sum(deriv_struct(i,3)) == 0.0)) then
                
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)  
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)  
+          call contrib_cache_getdata_outer(len_s, S, 1, ds1, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu1, mat_sing=A)  
+          call contrib_cache_getdata_outer(len_s, S, 1, ds3, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu3, mat_sing=C)  
 
 !           Y = Y + ((-1.0)/(2.0)) * frequency_zero_or_sum(deriv_struct(i,1)) * A * B * C
           if (calc_contrib) then 
@@ -438,12 +472,10 @@ module rsp_perturbed_matrices
        elseif (.not.(frequency_zero_or_sum(deriv_struct(i,3)) == 0.0) .and. &
                     (frequency_zero_or_sum(deriv_struct(i,1)) == 0.0)) then
                
-          call contrib_cache_getdata_outer(len_s, S, 1, (/ deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)  
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)  
+          call contrib_cache_getdata_outer(len_s, S, 1, ds1, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu1, mat_sing=A)  
+          call contrib_cache_getdata_outer(len_s, S, 1, ds3, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu3, mat_sing=C)  
                
 !           Y = Y + ((-1.0)/(2.0)) * frequency_zero_or_sum(deriv_struct(i,3)) * A * B * C
           if (calc_contrib) then
@@ -452,6 +484,10 @@ module rsp_perturbed_matrices
           end if
 
        end if
+
+       deallocate(iu1)
+       deallocate(iu2)
+       deallocate(iu3)
 
     end do
 
@@ -474,7 +510,9 @@ module rsp_perturbed_matrices
     logical :: select_terms, calc_contrib
     integer :: i, total_num_perturbations, superstructure_size, indices_len
     type(p_tuple), dimension(superstructure_size, 3) :: deriv_struct
-    type(p_tuple) :: merged_p_tuple
+    type(p_tuple), dimension(1) :: merged_p_tuple
+    type(p_tuple), dimension(1) :: ds1, ds2, ds3
+    integer, dimension(:), allocatable :: iu1, iu2, iu3, ium
     integer, dimension(2) :: kn
     integer, dimension(total_num_perturbations) :: which_index_is_pid
     integer, dimension(indices_len) :: ind
@@ -502,21 +540,34 @@ module rsp_perturbed_matrices
 
     do i = 1, superstructure_size
 
+       ds1(1) = deriv_struct(i,1)
+       ds2(1) = deriv_struct(i,2)
+       ds3(1) = deriv_struct(i,3)
+
+       allocate(iu1(ds1(1)%npert))
+       allocate(iu2(ds2(1)%npert))
+       allocate(iu3(ds3(1)%npert))
+
+       iu1 = get_fds_data_index(ds1(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+       iu2 = get_fds_data_index(ds2(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+       iu3 = get_fds_data_index(ds3(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+
+
        if (.not.select_terms) then
          calc_contrib = .true.
        else
          calc_contrib = .not.find_residue_info(deriv_struct(i,2))
        end if
 
-       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-       call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)             
-       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)
+       call contrib_cache_getdata_outer(len_d, D, 1, ds1, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu1, mat_sing=A) 
+       call contrib_cache_getdata_outer(len_s, S, 1, ds2, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu2, mat_sing=B)             
+       call contrib_cache_getdata_outer(len_d, D, 1, ds3, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu3, mat_sing=C)
             
 !        Z = Z + A*B*C
        if (calc_contrib) then 
@@ -524,22 +575,32 @@ module rsp_perturbed_matrices
          call QcMatRAXPY(1.0d0, T, Z)
        end if
 
+       deallocate(iu1)
+       deallocate(iu2)
+       deallocate(iu3)
+
     end do
 
-    merged_p_tuple = merge_p_tuple(deriv_struct(1,1), merge_p_tuple(deriv_struct(1,2), deriv_struct(1,3)))
+    merged_p_tuple(1) = merge_p_tuple(deriv_struct(1,1), merge_p_tuple(deriv_struct(1,2), deriv_struct(1,3)))
 
-    if (kn_skip(total_num_perturbations, merged_p_tuple%pid, kn) .eqv. .FALSE.) then
+    allocate(ium(total_num_perturbations))
 
-       call contrib_cache_getdata_outer(len_d, D, 1, (/merged_p_tuple/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_p_tuple, &
-        total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
+    ium = (/get_fds_data_index(merged_p_tuple(1), &
+        total_num_perturbations, which_index_is_pid, indices_len, ind)/)
+
+    if (kn_skip(total_num_perturbations, merged_p_tuple(1)%pid, kn) .eqv. .FALSE.) then
+
+       call contrib_cache_getdata_outer(len_d, D, 1, merged_p_tuple, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=ium, mat_sing=A) 
             
 !         Z = Z - A
         call QcMatRAXPY(-1.0d0, A, Z)
 
     end if
 
-    call p_tuple_deallocate(merged_p_tuple)
+    deallocate(ium)
+
+    call p_tuple_deallocate(merged_p_tuple(1))
 
     call QcMatDst(A)
     call QcMatDst(B)
@@ -558,10 +619,13 @@ module rsp_perturbed_matrices
     implicit none
 
     integer :: i, total_num_perturbations, superstructure_size, indices_len
-    type(p_tuple) :: p_tuple_a, merged_A, merged_B
+    type(p_tuple) :: p_tuple_a
+    type(p_tuple), dimension(1) :: merged_A, merged_B
     type(p_tuple), dimension(superstructure_size, 3) :: deriv_struct
     integer, dimension(total_num_perturbations) :: which_index_is_pid
     integer, dimension(indices_len) :: ind
+    type(p_tuple), dimension(1) :: ds1, ds2, ds3
+    integer, dimension(:), allocatable :: iu1, iu2, iu3, iuma, iumb
     integer :: len_d, len_s
     type(contrib_cache_outer), dimension(len_d) :: D
     type(contrib_cache_outer), dimension(len_S) :: S
@@ -587,6 +651,22 @@ module rsp_perturbed_matrices
     
 
     do i = 1, superstructure_size
+
+       ds1(1) = deriv_struct(i,1)
+       ds2(1) = deriv_struct(i,2)
+       ds3(1) = deriv_struct(i,3)
+
+       allocate(iu1(ds1(1)%npert))
+       allocate(iu2(ds2(1)%npert))
+       allocate(iu3(ds3(1)%npert))
+
+       iu1 = get_fds_data_index(ds1(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+       iu2 = get_fds_data_index(ds2(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+       iu3 = get_fds_data_index(ds3(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+
             
        if (select_terms) then
       
@@ -598,38 +678,49 @@ module rsp_perturbed_matrices
       if (calc_contrib) then
       
 
-       merged_A = merge_p_tuple(p_tuple_a, deriv_struct(i,1))
-       merged_B = merge_p_tuple(p_tuple_a, deriv_struct(i,3))
+       merged_A(1) = merge_p_tuple(p_tuple_a, deriv_struct(i,1))
+       merged_B(1) = merge_p_tuple(p_tuple_a, deriv_struct(i,3))
 
-       call contrib_cache_getdata_outer(len_d, D, 1, (/merged_A/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_A, &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-       call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B) 
-       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)    
+       allocate(iuma(merged_A(1)%npert))
+       allocate(iumb(merged_B(1)%npert))
+
+       iuma = (/get_fds_data_index(merged_A(1), &
+            total_num_perturbations, which_index_is_pid, indices_len, ind)/)
+
+       iumb = (/get_fds_data_index(merged_B(1), &
+            total_num_perturbations, which_index_is_pid, indices_len, ind)/)
+
+       call contrib_cache_getdata_outer(len_d, D, 1, merged_A, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iuma, mat_sing=A) 
+       call contrib_cache_getdata_outer(len_s, S, 1, ds2, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu2, mat_sing=B) 
+       call contrib_cache_getdata_outer(len_d, D, 1, ds3, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu3, mat_sing=C)    
             
 !        L = L + A * B * C
        call QcMatkABC(1.0d0, A, B, C, T)
        call QcMatRAXPY(1.0d0, T, L)            
             
-       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-       call contrib_cache_getdata_outer(len_d, D, 1, (/merged_B/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_B, &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)             
+       call contrib_cache_getdata_outer(len_d, D, 1, ds1, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu1, mat_sing=A) 
+       call contrib_cache_getdata_outer(len_d, D, 1, merged_B, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iumb, mat_sing=C)             
 
 !        L = L - A * B * C
        call QcMatkABC(-1.0d0, A, B, C, T)
        call QcMatRAXPY(1.0d0, T, L)    
 
-       call p_tuple_deallocate(merged_A)
-       call p_tuple_deallocate(merged_B)
+       call p_tuple_deallocate(merged_A(1))
+       call p_tuple_deallocate(merged_B(1))
+
+       deallocate(iuma)
+       deallocate(iumb)
 
       end if
+
+       deallocate(iu1)
+       deallocate(iu2)
+       deallocate(iu3)
        
     end do
     
@@ -650,12 +741,15 @@ module rsp_perturbed_matrices
     implicit none
 
     integer :: i, total_num_perturbations, superstructure_size, indices_len, j
-    type(p_tuple) :: p_tuple_a, merged_p_tuple, merged_A, merged_B
+    type(p_tuple) :: p_tuple_a
+    type(p_tuple), dimension(1) :: merged_p_tuple, merged_A, merged_B
     type(p_tuple), dimension(superstructure_size, 3) :: deriv_struct
     integer, dimension(2) :: kn
     integer, dimension(total_num_perturbations) :: which_index_is_pid
     integer, dimension(indices_len) :: ind
     integer :: len_f, len_d, len_s
+    type(p_tuple), dimension(1) :: ds1, ds2, ds3
+    integer, dimension(:), allocatable :: iu1, iu2, iu3, ium, iuma, iumb
     type(contrib_cache_outer), dimension(len_f) :: F
     type(contrib_cache_outer), dimension(len_d) :: D
     type(contrib_cache_outer), dimension(len_S) :: S
@@ -681,6 +775,33 @@ module rsp_perturbed_matrices
 
     do i = 1, superstructure_size
 
+       ds1(1) = deriv_struct(i,1)
+       ds2(1) = deriv_struct(i,2)
+       ds3(1) = deriv_struct(i,3)
+
+       allocate(iu1(ds1(1)%npert))
+       allocate(iu2(ds2(1)%npert))
+       allocate(iu3(ds3(1)%npert))
+
+       merged_A(1) = merge_p_tuple(p_tuple_a, deriv_struct(i,1))
+       merged_B(1) = merge_p_tuple(p_tuple_a, deriv_struct(i,3))
+
+       allocate(iuma(merged_A(1)%npert))
+       allocate(iumb(merged_B(1)%npert))
+       
+       iuma = (/get_fds_data_index(merged_A(1), &
+            total_num_perturbations, which_index_is_pid, indices_len, ind)/)
+
+       iumb = (/get_fds_data_index(merged_B(1), &
+            total_num_perturbations, which_index_is_pid, indices_len, ind)/)
+
+       iu1 = get_fds_data_index(ds1(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+       iu2 = get_fds_data_index(ds2(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+       iu3 = get_fds_data_index(ds3(1), total_num_perturbations, which_index_is_pid, &
+            indices_len, ind)
+
      if (select_terms) then 
      
         calc_contrib = .not.find_residue_info(deriv_struct(i,3))
@@ -689,18 +810,13 @@ module rsp_perturbed_matrices
 
      if (calc_contrib) then     
     
-       merged_A = merge_p_tuple(p_tuple_a, deriv_struct(i,1))
-       merged_B = merge_p_tuple(p_tuple_a, deriv_struct(i,3))
 
-       call contrib_cache_getdata_outer(len_f, F, 1, (/merged_A/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_A, &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)   
-       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)
-       call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)            
+       call contrib_cache_getdata_outer(len_f, F, 1, merged_A, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iuma, mat_sing=A)   
+       call contrib_cache_getdata_outer(len_d, D, 1, ds2, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu2, mat_sing=B)
+       call contrib_cache_getdata_outer(len_s, S, 1, ds3, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu3, mat_sing=C)            
      
 !        Zeta = Zeta + A * B * C
        call QcMatkABC(1.0d0, A, B, C, T)
@@ -710,18 +826,16 @@ module rsp_perturbed_matrices
      
      if (select_terms) then
      
-        calc_contrib = .not.find_residue_info(merged_B)
+        calc_contrib = .not.find_residue_info(merged_B(1))
         
      end if
 
      if (calc_contrib) then
  
-       call contrib_cache_getdata_outer(len_f, F, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)          
-       call contrib_cache_getdata_outer(len_s, S, 1, (/merged_B/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_B, &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)       
+       call contrib_cache_getdata_outer(len_f, F, 1, ds1, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu1, mat_sing=A)          
+       call contrib_cache_getdata_outer(len_s, S, 1, merged_B, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iumb, mat_sing=C)       
             
 !        Zeta = Zeta - A * B * C
 
@@ -741,9 +855,8 @@ module rsp_perturbed_matrices
        if (.not.(frequency_zero_or_sum(deriv_struct(i,1)) == 0.0) .and. &
            .not.(frequency_zero_or_sum(deriv_struct(i,2)) == 0.0)) then
                
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)                     
+          call contrib_cache_getdata_outer(len_s, S, 1, ds1, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu1, mat_sing=A)                     
 
 !           Zeta = Zeta + ( ((1.0)/(2.0))*frequency_zero_or_sum(deriv_struct(i,1)) + &
 !                            frequency_zero_or_sum(deriv_struct(i,2)) ) * A * B * C
@@ -754,9 +867,8 @@ module rsp_perturbed_matrices
        elseif (.not.(frequency_zero_or_sum(deriv_struct(i,1)) == 0.0) .and. &
                     (frequency_zero_or_sum(deriv_struct(i,2)) == 0.0)) then
 
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)  
+          call contrib_cache_getdata_outer(len_s, S, 1, ds1, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu1, mat_sing=A)  
 
 !           Zeta = Zeta + ((1.0)/(2.0))*frequency_zero_or_sum(deriv_struct(i,1)) * A * B * C
           call QcMatcABC(((1.0d0)/(2.0d0))*frequency_zero_or_sum(deriv_struct(i,1)), A, B, C, T)
@@ -765,9 +877,8 @@ module rsp_perturbed_matrices
        elseif (.not.(frequency_zero_or_sum(deriv_struct(i,2)) == 0.0) .and. &
                     (frequency_zero_or_sum(deriv_struct(i,1)) == 0.0)) then
 
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)                 
+          call contrib_cache_getdata_outer(len_s, S, 1, ds1, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu1, mat_sing=A)                 
 
 !           Zeta = Zeta + frequency_zero_or_sum(deriv_struct(i,2)) * A * B * C
           call QcMatcABC(frequency_zero_or_sum(deriv_struct(i,2)), A, B, C, T)
@@ -785,15 +896,12 @@ module rsp_perturbed_matrices
 
      if (calc_contrib) then
 
-       call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B) 
-       call contrib_cache_getdata_outer(len_f, F, 1, (/merged_B/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_B, &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C) 
+       call contrib_cache_getdata_outer(len_s, S, 1, ds1, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu1, mat_sing=A) 
+       call contrib_cache_getdata_outer(len_d, D, 1, ds2, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu2, mat_sing=B) 
+       call contrib_cache_getdata_outer(len_f, F, 1, merged_B, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iumb, mat_sing=C) 
             
 !        Zeta = Zeta +  A * B * C
        call QcMatkABC(1.0d0, A, B, C, T)
@@ -803,18 +911,16 @@ module rsp_perturbed_matrices
 
      if (select_terms) then 
      
-        calc_contrib = .not.find_residue_info(merged_A) 
+        calc_contrib = .not.find_residue_info(merged_A(1)) 
         
      end if
 
       if (calc_contrib) then
                  
-       call contrib_cache_getdata_outer(len_s, S, 1, (/merged_A/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_A, &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-       call contrib_cache_getdata_outer(len_f, F, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-            total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C) 
+       call contrib_cache_getdata_outer(len_s, S, 1, merged_A, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iuma, mat_sing=A) 
+       call contrib_cache_getdata_outer(len_f, F, 1, ds3, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=iu3, mat_sing=C) 
 
 !        Zeta = Zeta - A * B * C
        call QcMatkABC(1.0d0, A, B, C, T)
@@ -833,9 +939,8 @@ module rsp_perturbed_matrices
        if (.not.(frequency_zero_or_sum(deriv_struct(i,2)) == 0.0) .and. &
            .not.(frequency_zero_or_sum(deriv_struct(i,3)) == 0.0)) then
                     
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C) 
+          call contrib_cache_getdata_outer(len_s, S, 1, ds3, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu3, mat_sing=C) 
 
 !           Zeta = Zeta - ( ((1.0)/(2.0))*frequency_zero_or_sum(deriv_struct(i,3)) + &
 !                         frequency_zero_or_sum(deriv_struct(i,2)) ) * A * B * C
@@ -846,9 +951,8 @@ module rsp_perturbed_matrices
        elseif (.not.(frequency_zero_or_sum(deriv_struct(i,3)) == 0.0) .and. &
                     (frequency_zero_or_sum(deriv_struct(i,2)) == 0.0)) then
 
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C) 
+          call contrib_cache_getdata_outer(len_s, S, 1, ds3, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu3, mat_sing=C) 
 
 !           Zeta = Zeta - ((1.0)/(2.0))*frequency_zero_or_sum(deriv_struct(i,3)) * A * B * C
           call QcMatcABC(((-1.0d0)/(2.0d0))*frequency_zero_or_sum(deriv_struct(i,3)), A, B, C, T)
@@ -857,9 +961,8 @@ module rsp_perturbed_matrices
        elseif (.not.(frequency_zero_or_sum(deriv_struct(i,2)) == 0.0) .and. &
                     (frequency_zero_or_sum(deriv_struct(i,3)) == 0.0)) then
 
-          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
-               ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
-               total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C) 
+          call contrib_cache_getdata_outer(len_s, S, 1, ds3, .FALSE., contrib_size=1, &
+               ind_len=indices_len, ind_unsorted=iu3, mat_sing=C) 
 
 !           Zeta = Zeta - frequency_zero_or_sum(deriv_struct(i,2)) * A * B * C
           call QcMatcABC(-1.0d0 * frequency_zero_or_sum(deriv_struct(i,2)), A, B, C, T)
@@ -869,29 +972,43 @@ module rsp_perturbed_matrices
 
       end if
 
-       call p_tuple_deallocate(merged_A)
-       call p_tuple_deallocate(merged_B)
+       call p_tuple_deallocate(merged_A(1))
+       call p_tuple_deallocate(merged_B(1))
+
+       deallocate(iu1)
+       deallocate(iu2)
+       deallocate(iu3)
+
+       deallocate(iuma)
+       deallocate(iumb)
          
     end do
 
-    merged_p_tuple = merge_p_tuple(p_tuple_a, merge_p_tuple(deriv_struct(1,1), &
+    merged_p_tuple(1) = merge_p_tuple(p_tuple_a, merge_p_tuple(deriv_struct(1,1), &
                      merge_p_tuple(deriv_struct(1,2), deriv_struct(1,3))))
+
+    allocate(ium(total_num_perturbations))
+
+    ium = (/get_fds_data_index(merged_p_tuple(1), &
+       total_num_perturbations, which_index_is_pid, indices_len, ind)/)
+
 
     ! NOTE JAN 16: Does not seem likely that the skip condition will ever be met here: Any calculation
     ! of Zeta should already be "not skip" for this merged tuple
-    if (kn_skip(merged_p_tuple%npert, &
-        merged_p_tuple%pid, kn) .eqv. .FALSE.) then
+    if (kn_skip(merged_p_tuple(1)%npert, &
+        merged_p_tuple(1)%pid, kn) .eqv. .FALSE.) then
 
-       call contrib_cache_getdata_outer(len_f, F, 1, (/merged_p_tuple/), .FALSE., contrib_size=1, &
-            ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_p_tuple, & 
-       total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
+       call contrib_cache_getdata_outer(len_f, F, 1, merged_p_tuple, .FALSE., contrib_size=1, &
+            ind_len=indices_len, ind_unsorted=ium, mat_sing=A) 
             
 !        Zeta = Zeta - A
        call QcMatRAXPY(-1.0d0, A, Zeta)         
 
     end if
 
-    call p_tuple_deallocate(merged_p_tuple)
+    deallocate(ium)
+
+    call p_tuple_deallocate(merged_p_tuple(1))
 
     call QcMatDst(A)
     call QcMatDst(B)

--- a/src/ao_dens/rsp_perturbed_matrices.f90
+++ b/src/ao_dens/rsp_perturbed_matrices.f90
@@ -923,8 +923,16 @@ module rsp_perturbed_matrices
        allocate(get_fds_data_index(pert_tuple%npert))
 
        do i = 1, pert_tuple%npert
+! FIXME: UNSURE ABOUT NEXT LINE                                                                              
+! Will use just the regular index, but change back if this causes problems                         
+          get_fds_data_index(i) = indices(i)
 
-          get_fds_data_index(i) = indices(which_index_is_pid(pert_tuple%pid(i)))
+! NEXT LINE WAS THE ORIGINAL LINE, IT HAS GONE OUT OF BOUNDS AT LEAST ONCE
+!          get_fds_data_index(i) = indices(which_index_is_pid(pert_tuple%pid(i)))          
+
+
+
+
 
        end do
 

--- a/src/ao_dens/rsp_perturbed_matrices.f90
+++ b/src/ao_dens/rsp_perturbed_matrices.f90
@@ -536,7 +536,7 @@ module rsp_perturbed_matrices
     
     end if
  
- 
+write(*,*) 'in z which ind is pid', which_index_is_pid 
 
     do i = 1, superstructure_size
 
@@ -547,6 +547,19 @@ module rsp_perturbed_matrices
        allocate(iu1(ds1(1)%npert))
        allocate(iu2(ds2(1)%npert))
        allocate(iu3(ds3(1)%npert))
+       
+   write(*,*) 'i is', i
+   write(*,*) 'ds1 npert', ds1(1)%npert
+   write(*,*) 'ds2 npert', ds2(1)%npert
+   write(*,*) 'ds3 npert', ds3(1)%npert
+   
+   write(*,*) 'ds1 pid', ds1(1)%pid
+   write(*,*) 'ds2 pid', ds2(1)%pid
+   write(*,*) 'ds3 pid', ds3(1)%pid
+   
+      write(*,*) 'ds1 lab', ds1(1)%plab
+   write(*,*) 'ds2 lab', ds2(1)%plab
+   write(*,*) 'ds3 lab', ds3(1)%plab
 
        iu1 = get_fds_data_index(ds1(1), total_num_perturbations, which_index_is_pid, &
             indices_len, ind)
@@ -554,6 +567,10 @@ module rsp_perturbed_matrices
             indices_len, ind)
        iu3 = get_fds_data_index(ds3(1), total_num_perturbations, which_index_is_pid, &
             indices_len, ind)
+            
+    write(*,*) 'iu1', iu1
+    write(*,*) 'iu2', iu2
+    write(*,*) 'iu3', iu3
 
 
        if (.not.select_terms) then
@@ -1042,10 +1059,10 @@ module rsp_perturbed_matrices
        do i = 1, pert_tuple%npert
 ! FIXME: UNSURE ABOUT NEXT LINE                                                                              
 ! Will use just the regular index, but change back if this causes problems                         
-          get_fds_data_index(i) = indices(i)
+!          get_fds_data_index(i) = indices(i)
 
 ! NEXT LINE WAS THE ORIGINAL LINE, IT HAS GONE OUT OF BOUNDS AT LEAST ONCE
-!          get_fds_data_index(i) = indices(which_index_is_pid(pert_tuple%pid(i)))          
+          get_fds_data_index(i) = indices(which_index_is_pid(pert_tuple%pid(i)))          
 
 
 

--- a/src/ao_dens/rsp_perturbed_matrices.f90
+++ b/src/ao_dens/rsp_perturbed_matrices.f90
@@ -182,7 +182,7 @@ module rsp_perturbed_matrices
   ! Calculate a perturbed W matrix
   subroutine rsp_get_matrix_w(superstructure_size, &
            deriv_struct, total_num_perturbations, which_index_is_pid, &
-           indices_len, ind, F, D, S, W)
+           indices_len, ind, len_f, F, len_d, D, len_s, S, W)
 
     implicit none
 
@@ -190,7 +190,10 @@ module rsp_perturbed_matrices
     type(p_tuple), dimension(superstructure_size, 3) :: deriv_struct
     integer, dimension(total_num_perturbations) :: which_index_is_pid
     integer, dimension(indices_len) :: ind
-    type(contrib_cache_outer) :: F, D, S
+    integer :: len_f, len_d, len_s
+    type(contrib_cache_outer), dimension(len_f) :: F
+    type(contrib_cache_outer), dimension(len_d) :: D
+    type(contrib_cache_outer), dimension(len_S) :: S
     type(QcMat) :: W, A, B, C, T
     logical :: calc_contrib
 
@@ -202,13 +205,13 @@ module rsp_perturbed_matrices
     
     do i = 1, superstructure_size
 
-       call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-       call contrib_cache_getdata_outer(F, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_f, F, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)                
-       call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)       
 
@@ -223,13 +226,13 @@ module rsp_perturbed_matrices
          if (.not.(frequency_zero_or_sum(deriv_struct(i,1)) == 0.0) .and. &
              .not.(frequency_zero_or_sum(deriv_struct(i,3)) == 0.0)) then
 
-          call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)                
-          call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)               
                
@@ -245,13 +248,13 @@ module rsp_perturbed_matrices
          elseif (.not.(frequency_zero_or_sum(deriv_struct(i,1)) == 0.0) .and. &
                       (frequency_zero_or_sum(deriv_struct(i,3)) == 0.0)) then
 
-          call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)                
-          call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)               
 
@@ -265,13 +268,13 @@ module rsp_perturbed_matrices
          elseif (.not.(frequency_zero_or_sum(deriv_struct(i,3)) == 0.0) .and. &
                       (frequency_zero_or_sum(deriv_struct(i,1)) == 0.0)) then
                
-          call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)                
-          call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)                
 
@@ -295,7 +298,7 @@ module rsp_perturbed_matrices
   ! Calculate a perturbed Y matrix
   subroutine rsp_get_matrix_y(superstructure_size, deriv_struct, &
            total_num_perturbations, which_index_is_pid, indices_len, &
-           ind, F, D, S, Y, select_terms_arg)
+           ind, len_f, F, len_d, D, len_s, S, Y, select_terms_arg)
 
     implicit none
 
@@ -305,7 +308,10 @@ module rsp_perturbed_matrices
     type(p_tuple), dimension(superstructure_size, 3) :: deriv_struct
     integer, dimension(total_num_perturbations) :: which_index_is_pid
     integer, dimension(indices_len) :: ind
-    type(contrib_cache_outer) :: F, D, S
+    integer :: len_f, len_d, len_s
+    type(contrib_cache_outer), dimension(len_f) :: F
+    type(contrib_cache_outer), dimension(len_d) :: D
+    type(contrib_cache_outer), dimension(len_S) :: S
     type(QcMat) :: Y, A, B, C, T
 
     call QcMatInit(A)
@@ -331,13 +337,13 @@ module rsp_perturbed_matrices
          calc_contrib = .not.find_residue_info(deriv_struct(i,3))
        end if
 
-       call contrib_cache_getdata_outer(F, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_f, F, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)             
-       call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)             
-       call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C) 
 
@@ -354,7 +360,7 @@ module rsp_perturbed_matrices
           else
             calc_contrib = .not.(find_residue_info(deriv_struct(i,1)).or.find_residue_info(deriv_struct(i,3)))
           end if
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)
 
@@ -372,10 +378,10 @@ module rsp_perturbed_matrices
        else 
           calc_contrib = .not.find_residue_info(deriv_struct(i,1))
        end if
-       call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)  
-       call contrib_cache_getdata_outer(F, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_f, F, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)  
                        
@@ -396,10 +402,10 @@ module rsp_perturbed_matrices
           ! MaR: MAKE SURE THAT THESE (AND B) ARE ACTUALLY THE CORRECT 
           ! MATRICES TO USE HERE AND BELOW
 
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)  
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)  
        
@@ -416,10 +422,10 @@ module rsp_perturbed_matrices
        elseif (.not.(frequency_zero_or_sum(deriv_struct(i,1)) == 0.0) .and. &
              (frequency_zero_or_sum(deriv_struct(i,3)) == 0.0)) then
                
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)  
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)  
 
@@ -432,10 +438,10 @@ module rsp_perturbed_matrices
        elseif (.not.(frequency_zero_or_sum(deriv_struct(i,3)) == 0.0) .and. &
                     (frequency_zero_or_sum(deriv_struct(i,1)) == 0.0)) then
                
-          call contrib_cache_getdata_outer(S, 1, (/ deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/ deriv_struct(i,1)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)  
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)  
                
@@ -460,7 +466,7 @@ module rsp_perturbed_matrices
   ! Calculate a perturbed Z matrix
   subroutine rsp_get_matrix_z(superstructure_size, deriv_struct, kn, &
            total_num_perturbations, which_index_is_pid, indices_len, &
-           ind, F, D, S, Z, select_terms_arg)
+           ind, len_f, F, len_d, D, len_s, S, Z, select_terms_arg)
 
     implicit none
 
@@ -472,7 +478,10 @@ module rsp_perturbed_matrices
     integer, dimension(2) :: kn
     integer, dimension(total_num_perturbations) :: which_index_is_pid
     integer, dimension(indices_len) :: ind
-    type(contrib_cache_outer) :: F, D, S
+    integer :: len_f, len_d, len_s
+    type(contrib_cache_outer), dimension(len_f) :: F
+    type(contrib_cache_outer), dimension(len_d) :: D
+    type(contrib_cache_outer), dimension(len_S) :: S
     type(QcMat) :: Z, A, B, C, T
 
     call QcMatInit(A)
@@ -499,13 +508,13 @@ module rsp_perturbed_matrices
          calc_contrib = .not.find_residue_info(deriv_struct(i,2))
        end if
 
-       call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-       call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)             
-       call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)
             
@@ -521,7 +530,7 @@ module rsp_perturbed_matrices
 
     if (kn_skip(total_num_perturbations, merged_p_tuple%pid, kn) .eqv. .FALSE.) then
 
-       call contrib_cache_getdata_outer(D, 1, (/merged_p_tuple/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_d, D, 1, (/merged_p_tuple/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_p_tuple, &
         total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
             
@@ -542,7 +551,8 @@ module rsp_perturbed_matrices
 
   ! Calculate a perturbed Lambda matrix
   subroutine rsp_get_matrix_lambda(p_tuple_a, superstructure_size, deriv_struct, &
-           total_num_perturbations, which_index_is_pid, indices_len, ind, D, S, L,&
+           total_num_perturbations, which_index_is_pid, indices_len, &
+           ind, len_d, D, len_s, S, L,&
            select_terms_arg)
 
     implicit none
@@ -552,7 +562,9 @@ module rsp_perturbed_matrices
     type(p_tuple), dimension(superstructure_size, 3) :: deriv_struct
     integer, dimension(total_num_perturbations) :: which_index_is_pid
     integer, dimension(indices_len) :: ind
-    type(contrib_cache_outer) :: D, S
+    integer :: len_d, len_s
+    type(contrib_cache_outer), dimension(len_d) :: D
+    type(contrib_cache_outer), dimension(len_S) :: S
     type(QcMat) :: L, A, B, C, T
     logical :: calc_contrib, select_terms
     logical, optional :: select_terms_arg
@@ -589,13 +601,13 @@ module rsp_perturbed_matrices
        merged_A = merge_p_tuple(p_tuple_a, deriv_struct(i,1))
        merged_B = merge_p_tuple(p_tuple_a, deriv_struct(i,3))
 
-       call contrib_cache_getdata_outer(D, 1, (/merged_A/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_d, D, 1, (/merged_A/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_A, &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-       call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B) 
-       call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)    
             
@@ -603,10 +615,10 @@ module rsp_perturbed_matrices
        call QcMatkABC(1.0d0, A, B, C, T)
        call QcMatRAXPY(1.0d0, T, L)            
             
-       call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-       call contrib_cache_getdata_outer(D, 1, (/merged_B/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_d, D, 1, (/merged_B/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_B, &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)             
 
@@ -633,7 +645,7 @@ module rsp_perturbed_matrices
   ! Calculate a perturbed Zeta matrix
   subroutine rsp_get_matrix_zeta(p_tuple_a, kn, superstructure_size, deriv_struct, &
            total_num_perturbations, which_index_is_pid, indices_len, &
-           ind, F, D, S, Zeta, select_terms_arg)
+           ind, len_f, F, len_d, D, len_s, S, Zeta, select_terms_arg)
 
     implicit none
 
@@ -643,7 +655,10 @@ module rsp_perturbed_matrices
     integer, dimension(2) :: kn
     integer, dimension(total_num_perturbations) :: which_index_is_pid
     integer, dimension(indices_len) :: ind
-    type(contrib_cache_outer) :: F, D, S
+    integer :: len_f, len_d, len_s
+    type(contrib_cache_outer), dimension(len_f) :: F
+    type(contrib_cache_outer), dimension(len_d) :: D
+    type(contrib_cache_outer), dimension(len_S) :: S
     type(QcMat) :: Zeta, A, B, C, T
     logical :: calc_contrib, select_terms
     logical, optional :: select_terms_arg
@@ -677,13 +692,13 @@ module rsp_perturbed_matrices
        merged_A = merge_p_tuple(p_tuple_a, deriv_struct(i,1))
        merged_B = merge_p_tuple(p_tuple_a, deriv_struct(i,3))
 
-       call contrib_cache_getdata_outer(F, 1, (/merged_A/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_f, F, 1, (/merged_A/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_A, &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)   
-       call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B)
-       call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)            
      
@@ -701,10 +716,10 @@ module rsp_perturbed_matrices
 
      if (calc_contrib) then
  
-       call contrib_cache_getdata_outer(F, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_f, F, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)          
-       call contrib_cache_getdata_outer(S, 1, (/merged_B/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_s, S, 1, (/merged_B/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_B, &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C)       
             
@@ -726,7 +741,7 @@ module rsp_perturbed_matrices
        if (.not.(frequency_zero_or_sum(deriv_struct(i,1)) == 0.0) .and. &
            .not.(frequency_zero_or_sum(deriv_struct(i,2)) == 0.0)) then
                
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)                     
 
@@ -739,7 +754,7 @@ module rsp_perturbed_matrices
        elseif (.not.(frequency_zero_or_sum(deriv_struct(i,1)) == 0.0) .and. &
                     (frequency_zero_or_sum(deriv_struct(i,2)) == 0.0)) then
 
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)  
 
@@ -750,7 +765,7 @@ module rsp_perturbed_matrices
        elseif (.not.(frequency_zero_or_sum(deriv_struct(i,2)) == 0.0) .and. &
                     (frequency_zero_or_sum(deriv_struct(i,1)) == 0.0)) then
 
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A)                 
 
@@ -770,13 +785,13 @@ module rsp_perturbed_matrices
 
      if (calc_contrib) then
 
-       call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,1)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,1), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-       call contrib_cache_getdata_outer(D, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_d, D, 1, (/deriv_struct(i,2)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,2), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=B) 
-       call contrib_cache_getdata_outer(F, 1, (/merged_B/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_f, F, 1, (/merged_B/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_B, &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C) 
             
@@ -794,10 +809,10 @@ module rsp_perturbed_matrices
 
       if (calc_contrib) then
                  
-       call contrib_cache_getdata_outer(S, 1, (/merged_A/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_s, S, 1, (/merged_A/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_A, &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
-       call contrib_cache_getdata_outer(F, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_f, F, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
             total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C) 
 
@@ -818,7 +833,7 @@ module rsp_perturbed_matrices
        if (.not.(frequency_zero_or_sum(deriv_struct(i,2)) == 0.0) .and. &
            .not.(frequency_zero_or_sum(deriv_struct(i,3)) == 0.0)) then
                     
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C) 
 
@@ -831,7 +846,7 @@ module rsp_perturbed_matrices
        elseif (.not.(frequency_zero_or_sum(deriv_struct(i,3)) == 0.0) .and. &
                     (frequency_zero_or_sum(deriv_struct(i,2)) == 0.0)) then
 
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C) 
 
@@ -842,7 +857,7 @@ module rsp_perturbed_matrices
        elseif (.not.(frequency_zero_or_sum(deriv_struct(i,2)) == 0.0) .and. &
                     (frequency_zero_or_sum(deriv_struct(i,3)) == 0.0)) then
 
-          call contrib_cache_getdata_outer(S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
+          call contrib_cache_getdata_outer(len_s, S, 1, (/deriv_struct(i,3)/), .FALSE., contrib_size=1, &
                ind_len=indices_len, ind_unsorted=(/get_fds_data_index(deriv_struct(i,3), &
                total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=C) 
 
@@ -867,7 +882,7 @@ module rsp_perturbed_matrices
     if (kn_skip(merged_p_tuple%npert, &
         merged_p_tuple%pid, kn) .eqv. .FALSE.) then
 
-       call contrib_cache_getdata_outer(F, 1, (/merged_p_tuple/), .FALSE., contrib_size=1, &
+       call contrib_cache_getdata_outer(len_f, F, 1, (/merged_p_tuple/), .FALSE., contrib_size=1, &
             ind_len=indices_len, ind_unsorted=(/get_fds_data_index(merged_p_tuple, & 
        total_num_perturbations, which_index_is_pid, indices_len, ind)/), mat_sing=A) 
             

--- a/src/ao_dens/rsp_perturbed_matrices.f90
+++ b/src/ao_dens/rsp_perturbed_matrices.f90
@@ -536,8 +536,6 @@ module rsp_perturbed_matrices
     
     end if
  
-write(*,*) 'in z which ind is pid', which_index_is_pid 
-
     do i = 1, superstructure_size
 
        ds1(1) = deriv_struct(i,1)
@@ -548,19 +546,6 @@ write(*,*) 'in z which ind is pid', which_index_is_pid
        allocate(iu2(ds2(1)%npert))
        allocate(iu3(ds3(1)%npert))
        
-   write(*,*) 'i is', i
-   write(*,*) 'ds1 npert', ds1(1)%npert
-   write(*,*) 'ds2 npert', ds2(1)%npert
-   write(*,*) 'ds3 npert', ds3(1)%npert
-   
-   write(*,*) 'ds1 pid', ds1(1)%pid
-   write(*,*) 'ds2 pid', ds2(1)%pid
-   write(*,*) 'ds3 pid', ds3(1)%pid
-   
-      write(*,*) 'ds1 lab', ds1(1)%plab
-   write(*,*) 'ds2 lab', ds2(1)%plab
-   write(*,*) 'ds3 lab', ds3(1)%plab
-
        iu1 = get_fds_data_index(ds1(1), total_num_perturbations, which_index_is_pid, &
             indices_len, ind)
        iu2 = get_fds_data_index(ds2(1), total_num_perturbations, which_index_is_pid, &
@@ -568,11 +553,6 @@ write(*,*) 'in z which ind is pid', which_index_is_pid
        iu3 = get_fds_data_index(ds3(1), total_num_perturbations, which_index_is_pid, &
             indices_len, ind)
             
-    write(*,*) 'iu1', iu1
-    write(*,*) 'iu2', iu2
-    write(*,*) 'iu3', iu3
-
-
        if (.not.select_terms) then
          calc_contrib = .true.
        else

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -461,6 +461,9 @@ module rsp_perturbed_sdf
              k = k + 1
           end do
           
+          ptup_for_alr(1) = p_dummy_orders(pert%npert)
+          ptup_for_alr(2) = p_tuple_standardorder(pert)
+          
           call contrib_cache_add_element(len_cache, contribution_cache, 2, ptup_for_alr)
 
        end if
@@ -1210,7 +1213,7 @@ module rsp_perturbed_sdf
     logical :: termination, rsp_eqn_retrieved, residue_select, residualization
     logical :: init_xx, bool_arg
     integer :: num_outer, ind_ctr, npert_ext, sstr_incr, superstructure_size
-    integer :: i, j, k, m, n, w, nblks
+    integer :: i, j, k, m, n, w, nblks, v
     integer :: first, last, ierr
     integer, dimension(0) :: noc
     integer, dimension(3) :: prog_info, rs_info
@@ -1345,6 +1348,8 @@ module rsp_perturbed_sdf
        end if
        
        pert = cache_outer(m)%p_tuples(1)
+       
+       write(*,*) 'my pid is', pert%pid
 
        call mem_incr(mem_mgr, size_i(k))
        
@@ -1509,6 +1514,25 @@ module rsp_perturbed_sdf
                                residue_select = residue_select)
                                
           deallocate(arg_tuple)
+          
+                  do i = 1, size(Fp)
+    
+          if (i < 10) then
+             fmt_str = "(A3, I1)"
+          else if (i < 100) then
+             fmt_str = "(A3, I2)"
+          else
+             fmt_str = "(A3, I3)"
+          end if
+          
+          write(mat_str, fmt_str) 'Fprt', i
+          write(*,*) 'i', i
+          write(*,*) 'fname:', mat_str
+          
+          j = QcMatWrite_f(Fp(i), trim(mat_str), ASCII_VIEW)
+    
+    end do
+          
 
           ! XC call should go here
           
@@ -1613,7 +1637,9 @@ module rsp_perturbed_sdf
              allocate(arg_int_b(pert%npert))
 
              arg_int = (/pert%npert, pert%npert/)
-             arg_int_b = (/ (m, m = 1, pert%npert) /)
+             arg_int_b = (/ (v, v = 1, pert%npert) /)
+             write(*,*) 'j is', j
+             write(*,*) 'which ind is pid', arg_int_b
 
              call rsp_get_matrix_z(superstructure_size, derivative_structure, &
                   arg_int, pert%npert, &
@@ -1665,6 +1691,9 @@ module rsp_perturbed_sdf
           call contrib_cache_outer_add_element(len_d, D, .FALSE., 1, & 
                arg_tuple, data_size = size_i(k), data_mat = Dp(ind_ctr:ind_ctr + size_i(k) - 1) )
 
+
+
+               
 !stop
 
  !         write(*,*) 'after ccoae'
@@ -1685,7 +1714,27 @@ module rsp_perturbed_sdf
     
     end do
     
-       
+    ! Debug printing kept for later use    
+    do i = 1, size(Dp)
+    
+          if (i < 10) then
+             fmt_str = "(A3, I1)"
+          else if (i < 100) then
+             fmt_str = "(A3, I2)"
+          else
+             fmt_str = "(A3, I3)"
+          end if
+          
+          write(mat_str, fmt_str) 'Dpart_', i
+          write(*,*) 'i', i
+          write(*,*) 'fname:', mat_str
+          
+          j = QcMatWrite_f(Dp(i), trim(mat_str), ASCII_VIEW)
+    
+    end do
+
+    
+    
     
 ! ! Debug printing kept for later use    
 !     do i = 1, size(Dp)
@@ -1866,7 +1915,7 @@ module rsp_perturbed_sdf
 
              allocate(arg_int_b(pert%npert))
 
-             arg_int_b = (/ (m, m = 1, pert%npert) /)
+             arg_int_b = (/ (v, v = 1, pert%npert) /)
 
              call rsp_get_matrix_y(superstructure_size, derivative_structure, &
                   pert%npert, arg_int_b, &
@@ -2269,6 +2318,8 @@ module rsp_perturbed_sdf
                arg_tuple, data_size = size_i(k), data_mat = Fp(ind_ctr:ind_ctr + size_i(k) - 1) )
        
           len_d = size(D)
+          
+
        
           call contrib_cache_outer_add_element(len_d, D, .FALSE., 1, & 
                arg_tuple, data_size = size_i(k), data_mat = Dp(ind_ctr:ind_ctr + size_i(k) - 1) )
@@ -2279,6 +2330,26 @@ module rsp_perturbed_sdf
           k = k + 1
           
        end do
+       
+                 ! Debug printing kept for later use    
+    do i = 1, size(Dp)
+    
+          if (i < 10) then
+             fmt_str = "(A3, I1)"
+          else if (i < 100) then
+             fmt_str = "(A3, I2)"
+          else
+             fmt_str = "(A3, I3)"
+          end if
+          
+          write(mat_str, fmt_str) 'Dp_', i
+          write(*,*) 'i', i
+          write(*,*) 'fname:', mat_str
+          
+          j = QcMatWrite_f(Dp(i), trim(mat_str), ASCII_VIEW)
+    
+    end do
+       
        
        do i = 1, sum(size_i)
        

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -144,6 +144,8 @@ module rsp_perturbed_sdf
        k = 1
        do m = 1, size(cache(c_ord)%contribs_outer)
        
+          write(*,*) 'm is', m
+       
           ! Skip the dummy entry, who cares
           if (cache(c_ord)%contribs_outer(m)%dummy_entry) then
              cycle

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -332,8 +332,6 @@ module rsp_perturbed_sdf
        
        else
        
-          ! DEC 19: CONTINUE HERE
-       
           write(out_str, *) 'Calculating perturbed S, D, F at order', i
           call out_print(out_str, 1)
           write(out_str, *) ' '

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -99,9 +99,12 @@ module rsp_perturbed_sdf
           do j = 1, n_freq_cfgs(i)
           
              len_cache = size(cache)
+             write(*,*) 'about to call cache recurse, size is', size(cache)
           
              call rsp_fds_recurse(p_tuples(k), kn_rule(k, :), max_npert, p_dummy_orders, len_cache, cache, out_print)
              k = k + 1
+             
+             write(*,*) 'came back from recurse, size is now', size(cache)
 
           end do
        end do
@@ -119,9 +122,11 @@ module rsp_perturbed_sdf
     ! For each order of perturbation identified (lowest to highest):
     do i = 1, max_order
     
+       write(*,*) 'beginning order', i
+    
        lof_mem_total = 0
        
-       ! Will be determined below, this to avoir maybe-uninitialized warning
+       ! Will be determined below, this to avoid maybe-uninitialized warning
        c_ord = 0
     
        ! Find entry for this order
@@ -137,8 +142,12 @@ module rsp_perturbed_sdf
        
        end do
        
+       write(*,*) 'c ord after determination is', c_ord
+       
        ! Contains number of components of perturbed matrices for each perturbation
        allocate(size_i(cache(c_ord)%num_outer))
+       
+       write(*,*) 'before loop, size is', size(cache(c_ord)%contribs_outer)
        
        ! Traverse to set up size information
        k = 1
@@ -148,6 +157,8 @@ module rsp_perturbed_sdf
        
           ! Skip the dummy entry, who cares
           if (cache(c_ord)%contribs_outer(m)%dummy_entry) then
+          
+             write(*,*) 'I cycled for m =', m
              cycle
           end if
           
@@ -382,16 +393,11 @@ module rsp_perturbed_sdf
        
        call prog_incr(prog_info, r_flag, 2)
        
-          
+       deallocate(lof_cache)
+       
     end do
     
     deallocate(cache)
-    
-    if (max_order > 0) then
-    
-       deallocate(lof_cache)
-       
-    end if   
     
     deallocate(p_dummy_orders)
     
@@ -445,6 +451,10 @@ module rsp_perturbed_sdf
           write(out_str, *) ' '
           call out_print(out_str, 2)
                  
+          write(*, *) 'Identified perturbed S, D, F for calculation with labels ', pert%plab, &
+                            'and perturbation id ', pert%pid, ' with frequencies (real part)', &
+                             real(pert%freq)                  
+                 
           k = 1
 
           do j = 1, pert%npert
@@ -452,9 +462,15 @@ module rsp_perturbed_sdf
              k = k + 1
           end do
           
+          write(*,*) 'len cache before is', len_cache
+          write(*,*) 'actual size before is', size(contribution_cache)
+          
           call contrib_cache_add_element(len_cache, contribution_cache, 2, (/p_dummy_orders(pert%npert), &
                                                                   p_tuple_standardorder(pert)/))
 
+          write(*,*) 'len cache after is', len_cache
+          write(*,*) 'actual size after is', size(contribution_cache)
+                                                                  
        end if
 
     end if

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -449,10 +449,10 @@ module rsp_perturbed_sdf
           call out_print(out_str, 2)
           write(out_str, *) ' '
           call out_print(out_str, 2)
-                 
-          write(*, *) 'Identified perturbed S, D, F for calculation with labels ', pert%plab, &
-                            'and perturbation id ', pert%pid, ' with frequencies (real part)', &
-                             real(pert%freq)                  
+
+!          write(*, *) 'Identified perturbed S, D, F for calculation with labels ', pert%plab, &
+!                            'and perturbation id ', pert%pid, ' with frequencies (real part)', &
+!                             real(pert%freq)                  
                  
           k = 1
 
@@ -561,10 +561,7 @@ module rsp_perturbed_sdf
     ! If recursion is done, proceed to cache manipulation stage
     else
 
-write(*,*) 'calling ptst'
-
        p_tuples = p_tuples_standardorder(num_p_tuples, p_tuples)
-write(*,*) 'back from ptst'
 
        density_order_skip = .FALSE.
        residue_skip = .FALSE.
@@ -646,15 +643,11 @@ write(*,*) 'back from ptst'
                 write(out_str, *) ' '
                 call out_print(out_str, 2)
                 
-write(*,*) 'adding cache elem'
-
                 p_tuples_ord = p_tuples_standardorder(num_p_tuples, p_tuples)
 
                 call contrib_cache_add_element(len_lof_cache, fock_lowerorder_cache, &
                      num_p_tuples, p_tuples_ord)
 
-write(*,*) 'added cache elem'
-                
              else
              
                 write(out_str, *) 'ERROR: Wanted lower-order perturbed Fock matrix contribution but it was not in cache'
@@ -667,8 +660,6 @@ write(*,*) 'added cache elem'
        end if
 
     end if
-
-write(*,*) 'just before end'
 
   end subroutine
   
@@ -1217,7 +1208,7 @@ write(*,*) 'just before end'
     type(mem_manager) :: mem_mgr
     integer :: mctr, mcurr, miter, msize, octr, r_flag, mem_track
     logical :: termination, rsp_eqn_retrieved, residue_select, residualization
-    logical :: init_xx
+    logical :: init_xx, bool_arg
     integer :: num_outer, ind_ctr, npert_ext, sstr_incr, superstructure_size
     integer :: i, j, k, m, n, w, nblks
     integer :: first, last, ierr
@@ -1655,9 +1646,28 @@ write(*,*) 'just before end'
           allocate(arg_tuple(1))
 
           arg_tuple(1) = pert
+
+!          write(*,*) 'pert', arg_tuple(1)%npert
+!          write(*,*) 'pdim', arg_tuple(1)%pdim
+!          write(*,*) 'plab', arg_tuple(1)%plab
+!          write(*,*) 'pid', arg_tuple(1)%pid
+!          write(*,*) 'pfreq', arg_tuple(1)%freq
+          
+
+          
+ !         write(*,*) 'before ccoae'
+
+!         write(*,*) 'len d', len_d
+!          write(*,*) 'ind start', ind_ctr
+ !        write(*,*) 'ind end', ind_ctr + size_i(k) - 1
+!         write(*,*) 'actual size', size(Dp)
           
           call contrib_cache_outer_add_element(len_d, D, .FALSE., 1, & 
-               arg_tuple, data_size = size_i(k),  data_mat = Dp(ind_ctr:ind_ctr + size_i(k) - 1) )
+               arg_tuple, data_size = size_i(k), data_mat = Dp(ind_ctr:ind_ctr + size_i(k) - 1) )
+
+!stop
+
+ !         write(*,*) 'after ccoae'
                
           deallocate(arg_tuple)
 
@@ -1743,8 +1753,8 @@ write(*,*) 'just before end'
        arg_tuple(1) = pert_xc_null
        arg_int = (/1, 1/)
     
-       call rsp_xc_wrapper(1, arg_tuple, arg_int, size(D), D, get_xc_mat, out_print, &
-                                sum(size_i), mem_mgr, null_dmat=Dp, fock=Fp)
+!       call rsp_xc_wrapper(1, arg_tuple, arg_int, size(D), D, get_xc_mat, out_print, &
+!                               sum(size_i), mem_mgr, null_dmat=Dp, fock=Fp)
     
     
        deallocate(arg_int)
@@ -2195,8 +2205,8 @@ write(*,*) 'just before end'
      arg_tuple(1) = pert_xc_null
      arg_int = (/1, 1/)
 
-     call rsp_xc_wrapper(1, arg_tuple, arg_int, size(D), D, get_xc_mat, out_print, &
-                         sum(size_i), mem_mgr, null_dmat=Dh, fock=Fp)
+!     call rsp_xc_wrapper(1, arg_tuple, arg_int, size(D), D, get_xc_mat, out_print, &
+!                         sum(size_i), mem_mgr, null_dmat=Dh, fock=Fp)
 
 
      deallocate(arg_int)
@@ -2439,7 +2449,6 @@ write(*,*) 'just before end'
     
     call empty_p_tuple(emptypert(1))
 
-write(*,*) 'stage a'                  
     ! Special handling for null perturbation case
     
     if (pert(1)%npert == 1) then
@@ -2533,9 +2542,6 @@ write(*,*) 'stage a'
     end if
     
     
-    write(*,*) 'stage b'
-
-    
     if (present(fock)) then
     
        dmat_length = 2**pert(1)%npert
@@ -2560,9 +2566,6 @@ write(*,*) 'stage a'
 
     call p1_cloneto_p2(emptypert(1), dmat_perts(1))
 
-    write(*,*) 'stage c'
-
-    
     pert_ids(1) = 1
     ind_dmat_perts = 1
     rec_prog = 0
@@ -2622,8 +2625,6 @@ write(*,*) 'stage a'
     
     dmat_total_size = 1
     
-    write(*,*) 'stage d'
-
     ! For each perturbation subset in dmat_perts:
     
     do i = 2, dmat_length
@@ -2703,23 +2704,18 @@ end if
 
     end if
     
-            write(*,*) 'stage e'
     dmat_array_ctr = 1
         
-        write(*,*) 'stage ea'
     ! For each perturbation subset in dmat_perts:
    
     do i = 2, dmat_length
    
-    write(*,*) 'stage eb'
        ! For each freq config:
               
        do j = 1, n_freq_cfgs
        
-    write(*,*) 'stage ec'
           ! Dress dmat pert tuple with freqs from present freq config
           do k = 1, dmat_perts(i)%npert
-    write(*,*) 'stage ed'          
 
 ! FIXME: UNSURE ABOUT NEXT LINES                                                                              
 
@@ -2743,12 +2739,11 @@ write(*,*) 'ERROR: Must ask for either Fock matrix or property contribution'
 
 end if
 
-
-
           end do
 
-             write(*,*) 'dmp', i,' freq', dmat_perts(i)%freq
-             write(*,*) 'pert', i,' freq', pert(j)%freq
+!          write(*,*) 'dmp pid', dmat_perts(i)%pid
+!             write(*,*) 'dmp', i,' freq', dmat_perts(i)%freq
+!             write(*,*) 'pert', i,' freq', pert(j)%freq
           
           num_blks = get_num_blks(dmat_perts(i))
        
@@ -2757,6 +2752,7 @@ end if
           blk_info = get_blk_info(num_blks, dmat_perts(i))
           triang_size = get_triangulated_size(num_blks, blk_info)
 
+ !         write(*,*) 'stage a'
 
           ! Allocate and make indices
           allocate(curr_dmat_indices(triang_size, dmat_perts(i)%npert))
@@ -2777,15 +2773,16 @@ end if
 
                 pert_arg(1) = dmat_perts(i)
                 int_arg = curr_dmat_indices(k, :)
-    write(*,*) 'stage e2'
+
+!                write(*,*) 'stage b'
            
                 call contrib_cache_getdata_outer(len_d, D, 1, pert_arg, .FALSE., &
                               1, ind_len=size(curr_dmat_indices, 2), &
                               ind_unsorted=int_arg, &
                               mat_sing=dmat_total_array(dmat_array_ctr))
 
-    write(*,*) 'stage e3'
-                              
+!                write(*,*) 'stage c'
+
                 deallocate(int_arg)
                 deallocate(pert_arg)
 
@@ -2802,8 +2799,6 @@ end if
        end do
     
     end do
-
-    write(*,*) 'stage f'
 
     ! Get perturbation tuple in external representation
     call p_tuple_to_external_tuple(pert(1), pert(1)%npert, pert_ext)

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -99,13 +99,10 @@ module rsp_perturbed_sdf
           do j = 1, n_freq_cfgs(i)
           
              len_cache = size(cache)
-             write(*,*) 'about to call cache recurse, size is', size(cache)
           
              call rsp_fds_recurse(p_tuples(k), kn_rule(k, :), max_npert, p_dummy_orders, len_cache, cache, out_print)
              k = k + 1
              
-             write(*,*) 'came back from recurse, size is now', size(cache)
-
           end do
        end do
 
@@ -121,8 +118,6 @@ module rsp_perturbed_sdf
     
     ! For each order of perturbation identified (lowest to highest):
     do i = 1, max_order
-    
-       write(*,*) 'beginning order', i
     
        lof_mem_total = 0
        
@@ -142,23 +137,15 @@ module rsp_perturbed_sdf
        
        end do
        
-       write(*,*) 'c ord after determination is', c_ord
-       
        ! Contains number of components of perturbed matrices for each perturbation
        allocate(size_i(cache(c_ord)%num_outer))
-       
-       write(*,*) 'before loop, size is', size(cache(c_ord)%contribs_outer)
        
        ! Traverse to set up size information
        k = 1
        do m = 1, size(cache(c_ord)%contribs_outer)
        
-          write(*,*) 'm is', m
-       
           ! Skip the dummy entry, who cares
           if (cache(c_ord)%contribs_outer(m)%dummy_entry) then
-          
-             write(*,*) 'I cycled for m =', m
              cycle
           end if
           
@@ -462,15 +449,9 @@ module rsp_perturbed_sdf
              k = k + 1
           end do
           
-          write(*,*) 'len cache before is', len_cache
-          write(*,*) 'actual size before is', size(contribution_cache)
-          
           call contrib_cache_add_element(len_cache, contribution_cache, 2, (/p_dummy_orders(pert%npert), &
                                                                   p_tuple_standardorder(pert)/))
 
-          write(*,*) 'len cache after is', len_cache
-          write(*,*) 'actual size after is', size(contribution_cache)
-                                                                  
        end if
 
     end if

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -92,7 +92,7 @@ module rsp_perturbed_sdf
        call out_print(out_str, 1)
           
        allocate(cache)
-       call contrib_cache_retrieve(cache, 'OPENRSP_FDS_ID')
+!        call contrib_cache_retrieve(cache, 'OPENRSP_FDS_ID')
        lof_retrieved = .TRUE.
              
     else
@@ -112,7 +112,7 @@ module rsp_perturbed_sdf
           end do
        end do
 
-       call contrib_cache_store(cache, r_flag, 'OPENRSP_FDS_ID')
+!        call contrib_cache_store(cache, r_flag, 'OPENRSP_FDS_ID')
        
     end if
 
@@ -171,7 +171,7 @@ module rsp_perturbed_sdf
        
           if (.NOT.(lof_retrieved)) then
           
-             call contrib_cache_retrieve(lof_cache, 'OPENRSP_LOF_CACHE')
+!              call contrib_cache_retrieve(lof_cache, 'OPENRSP_LOF_CACHE')
              lof_retrieved = .TRUE.
              
           end if
@@ -213,7 +213,7 @@ module rsp_perturbed_sdf
        
           end do
           
-          call contrib_cache_store(lof_cache, r_flag, 'OPENRSP_LOF_CACHE')
+!           call contrib_cache_store(lof_cache, r_flag, 'OPENRSP_LOF_CACHE')
        
        end if
        
@@ -234,7 +234,7 @@ module rsp_perturbed_sdf
                     
           if (.NOT.(lof_retrieved)) then
           
-             call contrib_cache_retrieve(lof_cache, 'OPENRSP_LOF_CACHE')
+!              call contrib_cache_retrieve(lof_cache, 'OPENRSP_LOF_CACHE')
              lof_retrieved = .TRUE.
              
           end if
@@ -279,7 +279,7 @@ module rsp_perturbed_sdf
                 
                 if (.NOT.(mem_mgr%calibrate)) then
                 
-                   call contrib_cache_store(lof_cache, r_flag, 'OPENRSP_LOF_CACHE')
+!                    call contrib_cache_store(lof_cache, r_flag, 'OPENRSP_LOF_CACHE')
                    
                 end if
                 
@@ -316,13 +316,13 @@ module rsp_perturbed_sdf
           
           if (.NOT.(sdf_retrieved)) then
           
-             call contrib_cache_outer_retrieve(S, 'OPENRSP_S_CACHE', .FALSE.)
-             call contrib_cache_outer_retrieve(D, 'OPENRSP_D_CACHE', .FALSE.)
-             call contrib_cache_outer_retrieve(F, 'OPENRSP_F_CACHE', .FALSE.)
+!              call contrib_cache_outer_retrieve(S, 'OPENRSP_S_CACHE', .FALSE.)
+!              call contrib_cache_outer_retrieve(D, 'OPENRSP_D_CACHE', .FALSE.)
+!              call contrib_cache_outer_retrieve(F, 'OPENRSP_F_CACHE', .FALSE.)
              
              if (present(Xf)) then
        
-             call contrib_cache_outer_retrieve(Xf, 'OPENRSP_Xf_CACHE', .FALSE.)
+!              call contrib_cache_outer_retrieve(Xf, 'OPENRSP_Xf_CACHE', .FALSE.)
           
              end if
                        
@@ -369,9 +369,9 @@ module rsp_perturbed_sdf
           
              len_d = size(D)
           
-             call contrib_cache_outer_store(len_d, S, 'OPENRSP_S_CACHE', r_flag)
-             call contrib_cache_outer_store(len_d, D, 'OPENRSP_D_CACHE', r_flag)
-             call contrib_cache_outer_store(len_d, F, 'OPENRSP_F_CACHE', r_flag)
+!              call contrib_cache_outer_store(len_d, S, 'OPENRSP_S_CACHE', r_flag)
+!              call contrib_cache_outer_store(len_d, D, 'OPENRSP_D_CACHE', r_flag)
+!              call contrib_cache_outer_store(len_d, F, 'OPENRSP_F_CACHE', r_flag)
              
           end if
        
@@ -1746,7 +1746,7 @@ module rsp_perturbed_sdf
                       write(out_str, *) ' '
                       call out_print(out_str, 2)
                    
-                      call mat_scal_retrieve(rs_info(3), 'OPENRSP_MAT_RSP', mat=X(1:rs_info(3)))
+!                       call mat_scal_retrieve(rs_info(3), 'OPENRSP_MAT_RSP', mat=X(1:rs_info(3)))
                       rsp_eqn_retrieved = .TRUE.
                       
              
@@ -1788,7 +1788,7 @@ module rsp_perturbed_sdf
   
                       end if
                   
-                      call mat_scal_store(last - first + 1, 'OPENRSP_MAT_RSP', r_flag, &
+!                       call mat_scal_store(last - first + 1, 'OPENRSP_MAT_RSP', r_flag, &
                            mat=X(ind_ctr+first-1:ind_ctr+last-1), start_pos = ind_ctr+first-1)
                     
                    end if
@@ -1815,7 +1815,7 @@ module rsp_perturbed_sdf
          
              if (.NOT.(rsp_eqn_retrieved)) then
           
-                call mat_scal_retrieve(rs_info(3), 'OPENRSP_MAT_RSP', mat=X(1:rs_info(3)))
+!                 call mat_scal_retrieve(rs_info(3), 'OPENRSP_MAT_RSP', mat=X(1:rs_info(3)))
                 rsp_eqn_retrieved = .TRUE.
              
              end if
@@ -1847,7 +1847,7 @@ module rsp_perturbed_sdf
                                  RHS(ind_ctr:ind_ctr+size_i(k)-1),     &
                                  X(ind_ctr:ind_ctr+size_i(k)-1))
           
-                call mat_scal_store(size_i(k), 'OPENRSP_MAT_RSP', r_flag, &
+!                 call mat_scal_store(size_i(k), 'OPENRSP_MAT_RSP', r_flag, &
                            mat=X(ind_ctr:ind_ctr+size_i(k)-1), start_pos = ind_ctr)
                            
              end if

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -2631,7 +2631,8 @@ module rsp_perturbed_sdf
 
 if (present(fock)) then
 ! Will use just the regular index, but change back if this causes problems                          
-             dmat_perts(i)%freq(k) = pert(j)%freq(k)
+!              dmat_perts(i)%freq(k) = pert(j)%freq(k)
+             dmat_perts(i)%freq(k) = pert(j)%freq(dmat_perts(i)%pid(k))
 
 elseif (present(prop)) then
 ! NEXT LINE WAS THE ORIGINAL LINE, IT HAS GONE OUT OF BOUNDS AT LEAST ONCE FOR FOCK CONTRIB
@@ -2712,8 +2713,10 @@ end if
 
 if (present(fock)) then
 ! Will use just the regular index, but change back if this causes problems                                    
-             dmat_perts(i)%freq(k) = pert(j)%freq(k)
-
+!              dmat_perts(i)%freq(k) = pert(j)%freq(k)
+             dmat_perts(i)%freq(k) = pert(j)%freq(dmat_perts(i)%pid(k))
+             
+             
 elseif (present(prop)) then
 ! NEXT LINE WAS THE ORIGINAL LINE, IT HAS GONE OUT OF BOUNDS AT LEAST ONCE FOR FOCK CONTRIB                   
 !             dmat_perts(i)%freq(k) = pert(j)%freq(k)

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -450,9 +450,6 @@ module rsp_perturbed_sdf
           write(out_str, *) ' '
           call out_print(out_str, 2)
 
-!          write(*, *) 'Identified perturbed S, D, F for calculation with labels ', pert%plab, &
-!                            'and perturbation id ', pert%pid, ' with frequencies (real part)', &
-!                             real(pert%freq)                  
                  
           k = 1
 
@@ -1349,8 +1346,6 @@ module rsp_perturbed_sdf
        
        pert = cache_outer(m)%p_tuples(1)
        
-       write(*,*) 'my pid is', pert%pid
-
        call mem_incr(mem_mgr, size_i(k))
        
        if (.NOT.(mem_mgr%calibrate)) then
@@ -1515,24 +1510,6 @@ module rsp_perturbed_sdf
                                
           deallocate(arg_tuple)
           
-                  do i = 1, size(Fp)
-    
-          if (i < 10) then
-             fmt_str = "(A3, I1)"
-          else if (i < 100) then
-             fmt_str = "(A3, I2)"
-          else
-             fmt_str = "(A3, I3)"
-          end if
-          
-          write(mat_str, fmt_str) 'Fprt', i
-          write(*,*) 'i', i
-          write(*,*) 'fname:', mat_str
-          
-          j = QcMatWrite_f(Fp(i), trim(mat_str), ASCII_VIEW)
-    
-    end do
-          
 
           ! XC call should go here
           
@@ -1638,8 +1615,6 @@ module rsp_perturbed_sdf
 
              arg_int = (/pert%npert, pert%npert/)
              arg_int_b = (/ (v, v = 1, pert%npert) /)
-             write(*,*) 'j is', j
-             write(*,*) 'which ind is pid', arg_int_b
 
              call rsp_get_matrix_z(superstructure_size, derivative_structure, &
                   arg_int, pert%npert, &
@@ -1673,31 +1648,9 @@ module rsp_perturbed_sdf
 
           arg_tuple(1) = pert
 
-!          write(*,*) 'pert', arg_tuple(1)%npert
-!          write(*,*) 'pdim', arg_tuple(1)%pdim
-!          write(*,*) 'plab', arg_tuple(1)%plab
-!          write(*,*) 'pid', arg_tuple(1)%pid
-!          write(*,*) 'pfreq', arg_tuple(1)%freq
-          
-
-          
- !         write(*,*) 'before ccoae'
-
-!         write(*,*) 'len d', len_d
-!          write(*,*) 'ind start', ind_ctr
- !        write(*,*) 'ind end', ind_ctr + size_i(k) - 1
-!         write(*,*) 'actual size', size(Dp)
-          
           call contrib_cache_outer_add_element(len_d, D, .FALSE., 1, & 
                arg_tuple, data_size = size_i(k), data_mat = Dp(ind_ctr:ind_ctr + size_i(k) - 1) )
 
-
-
-               
-!stop
-
- !         write(*,*) 'after ccoae'
-               
           deallocate(arg_tuple)
 
        end if
@@ -1714,26 +1667,7 @@ module rsp_perturbed_sdf
     
     end do
     
-    ! Debug printing kept for later use    
-    do i = 1, size(Dp)
-    
-          if (i < 10) then
-             fmt_str = "(A3, I1)"
-          else if (i < 100) then
-             fmt_str = "(A3, I2)"
-          else
-             fmt_str = "(A3, I3)"
-          end if
-          
-          write(mat_str, fmt_str) 'Dpart_', i
-          write(*,*) 'i', i
-          write(*,*) 'fname:', mat_str
-          
-          j = QcMatWrite_f(Dp(i), trim(mat_str), ASCII_VIEW)
-    
-    end do
-
-    
+   
     
     
 ! ! Debug printing kept for later use    
@@ -2331,25 +2265,7 @@ module rsp_perturbed_sdf
           
        end do
        
-                 ! Debug printing kept for later use    
-    do i = 1, size(Dp)
-    
-          if (i < 10) then
-             fmt_str = "(A3, I1)"
-          else if (i < 100) then
-             fmt_str = "(A3, I2)"
-          else
-             fmt_str = "(A3, I3)"
-          end if
-          
-          write(mat_str, fmt_str) 'Dp_', i
-          write(*,*) 'i', i
-          write(*,*) 'fname:', mat_str
-          
-          j = QcMatWrite_f(Dp(i), trim(mat_str), ASCII_VIEW)
-    
-    end do
-       
+      
        
        do i = 1, sum(size_i)
        
@@ -2812,9 +2728,6 @@ end if
 
           end do
 
-!          write(*,*) 'dmp pid', dmat_perts(i)%pid
-!             write(*,*) 'dmp', i,' freq', dmat_perts(i)%freq
-!             write(*,*) 'pert', i,' freq', pert(j)%freq
           
           num_blks = get_num_blks(dmat_perts(i))
        
@@ -2822,8 +2735,6 @@ end if
           allocate(blk_sizes(num_blks))
           blk_info = get_blk_info(num_blks, dmat_perts(i))
           triang_size = get_triangulated_size(num_blks, blk_info)
-
- !         write(*,*) 'stage a'
 
           ! Allocate and make indices
           allocate(curr_dmat_indices(triang_size, dmat_perts(i)%npert))
@@ -2845,14 +2756,11 @@ end if
                 pert_arg(1) = dmat_perts(i)
                 int_arg = curr_dmat_indices(k, :)
 
-!                write(*,*) 'stage b'
-           
                 call contrib_cache_getdata_outer(len_d, D, 1, pert_arg, .FALSE., &
                               1, ind_len=size(curr_dmat_indices, 2), &
                               ind_unsorted=int_arg, &
                               mat_sing=dmat_total_array(dmat_array_ctr))
 
-!                write(*,*) 'stage c'
 
                 deallocate(int_arg)
                 deallocate(pert_arg)

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -2451,11 +2451,24 @@ end function
                      nfields, blks_tuple_info, blk_sizes, blks_tuple_triang_size, translated_index)
 
                   else
+
+                     allocate(blk_arg_a(size(blk_sizes(1,:))))
+                     
+                     blk_arg_a = blk_sizes(1,:)
+                     
+                     allocate(blk_arg_ii(size(blks_tuple_info,2),size(blks_tuple_info,3)))
+
+                     blk_arg_ii = blks_tuple_info(1,:,:)
+
                
                      cache_offset = get_triang_blks_tuple_offset(1, &
                      total_num_perturbations, nblks_tuple(1), & 
-                     nfields(1), blks_tuple_info(1,:,:), blk_sizes(1,:), &
+                     nfields(1), blk_arg_ii, blk_arg_a, &
                      blks_tuple_triang_size(1), translated_index)
+
+                     deallocate(blk_arg_ii)
+
+                     deallocate(blk_arg_a)
                
                   end if
             

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -2484,15 +2484,13 @@ end function
             
             if (present(mat)) then
             
-               write(*,*) 'res, cache offset', res_offset, cache_offset + cache_hard_offset
-            
                call QcMatRAXPY(1.0d0, cache(loc_found)%data_mat(cache_offset + &
                                cache_hard_offset), mat(res_offset))
                
             else if (present(scal)) then
             
-               write(*,*) 'res, cache offset', res_offset, cache_offset + cache_hard_offset
-               write(*,*) 'val', cache(loc_found)%data_scal(cache_offset + cache_hard_offset)              
+!                write(*,*) 'res, cache offset', res_offset, cache_offset + cache_hard_offset
+!                write(*,*) 'val', cache(loc_found)%data_scal(cache_offset + cache_hard_offset)              
 
                scal(res_offset) = &
                scal(res_offset) + &

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -2427,9 +2427,9 @@ end function
 
 ! FIXME: UNSURE ABOUT NEXT LINE
 ! Will use just the regular index, but change back if this causes problems
-               translated_index(j) = indices(i,j)
+!                translated_index(j) = indices(i,j)
 ! NEXT LINE WAS THE ORIGINAL LINE, IT HAS GONE OUT OF BOUNDS AT LEAST ONCE
-!               translated_index(j) = indices(i,pids_current_contrib(j))
+              translated_index(j) = indices(i,pids_current_contrib(j))
             end do
 
             if (p_tuples(1)%npert == 0) then
@@ -2484,13 +2484,15 @@ end function
             
             if (present(mat)) then
             
+               write(*,*) 'res, cache offset', res_offset, cache_offset + cache_hard_offset
+            
                call QcMatRAXPY(1.0d0, cache(loc_found)%data_mat(cache_offset + &
                                cache_hard_offset), mat(res_offset))
                
             else if (present(scal)) then
             
-               !write(*,*) 'res, cache offset', res_offset, cache_offset + cache_hard_offset
-               !write(*,*) 'val', next_element_outer%data_scal(cache_offset + cache_hard_offset)              
+               write(*,*) 'res, cache offset', res_offset, cache_offset + cache_hard_offset
+               write(*,*) 'val', cache(loc_found)%data_scal(cache_offset + cache_hard_offset)              
 
                scal(res_offset) = &
                scal(res_offset) + &
@@ -2553,6 +2555,8 @@ end function
     end if
    
       if (found) then
+      
+!         write(*,*) 'mat sing cache offset', offset + cache_hard_offset
       
          call QcMatAEqB(mat_sing, cache(loc_found)%data_mat(offset + cache_hard_offset))
          

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -1803,7 +1803,15 @@ module rsp_property_caching
       
       deallocate(cache)
       
+      write(*,*) 'len_cache arg is', len_cache
+      
+      write(*,*) 'cache size is', size(cache)
+      write(*,*) 'cache store is len', size(cache_store)
+      
+      
       allocate(cache(len_cache + 1))
+      
+      write(*,*) 'I allocated', len_cache + 1
       
       ! FIXME: May be necessary to copy element by element
       ! But I think that the default assignment method will work here
@@ -1903,7 +1911,7 @@ module rsp_property_caching
    else
    
 
-!       call contrib_cache_allocate(new_element)
+      allocate(new_element(1))
       
       if (present(n_rule)) then
          

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -1740,7 +1740,7 @@ write(*,*) 'all of loop done'
    type(contrib_cache_outer) :: new_element
   
 
-   type(p_tuple), dimension(num_dmat) :: outer_p_tuples, p_tuples_st_order
+   type(p_tuple), dimension(num_dmat) :: outer_p_tuples, p_tuples_st_order, pstcmp
    
    type(Qcmat), optional, dimension(*) :: data_mat
    complex(8), optional, dimension(*) :: data_scal
@@ -1763,11 +1763,13 @@ write(*,*) 'all of loop done'
       p_tuples_st_order = p_tuples_standardorder(num_dmat, outer_p_tuples)
    
       do i = 1, len_cache
+
+         pstcmp = p_tuples_standardorder(cache(i)%num_dmat, &
+            cache(i)%p_tuples)
       
          if (cache(i)%num_dmat == num_dmat .AND. .NOT.(cache(i)%dummy_entry)) then
             found_element = p_tuples_compare(cache(i)%num_dmat, &
-            p_tuples_standardorder(cache(i)%num_dmat, &
-            cache(i)%p_tuples), p_tuples_st_order)
+            pstcmp, p_tuples_st_order)
             
             if (found_element) then
                found_loc = i

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -1649,46 +1649,31 @@ module rsp_property_caching
    
         do i = 1, num_dmat
 
-write(*,*) 'setting up'
-
            allocate(blki_a(new_element%nblks_tuple(i)))
            allocate(blki_b(new_element%nblks_tuple(i)))
            allocate(blksi_a(new_element%nblks_tuple(i), &
 size(new_element%blks_tuple_info, 3) ))
 
-write(*,*) 'allocd'
-      
-
            new_element%blks_tuple_info(i, :, :) = get_blk_info(new_element%nblks_tuple(i), outer_p_tuples(i))
-
 
 
            blki_a = new_element%blks_tuple_info(i,1:new_element%nblks_tuple(i),2)
            blki_b = new_element%blks_tuple_info(i,1:new_element%nblks_tuple(i),3)
            blksi_a = new_element%blks_tuple_info(i, 1:new_element%nblks_tuple(i), :)
 
-write(*,*) 'assigned'
-
            new_element%blk_sizes(i, 1:new_element%nblks_tuple(i)) = &
            get_triangular_sizes(new_element%nblks_tuple(i), &
            blki_a, blki_b)
 
-write(*,*) 'blk info a done'
-
            new_element%blks_tuple_triang_size(i) = get_triangulated_size(new_element%nblks_tuple(i), &
            blksi_a)
                     
-write(*,*) 'blk info b done'
            deallocate(blki_a)
            deallocate(blki_b)
            deallocate(blksi_a)
-write(*,*) 'dealloc done'
-
                
         end do
      
-write(*,*) 'all of loop done'
-
         allocate(new_element%indices(product(new_element%blks_tuple_triang_size), total_npert))
         call make_triangulated_tuples_indices(num_dmat, total_npert, new_element%nblks_tuple, &
              new_element%blks_tuple_info, new_element%blks_tuple_triang_size, new_element%indices)
@@ -1745,6 +1730,7 @@ write(*,*) 'all of loop done'
    type(Qcmat), optional, dimension(*) :: data_mat
    complex(8), optional, dimension(*) :: data_scal
 
+
    if (present(n_rule)) then
    
       already = contrib_cache_already_outer(len_cache, cache, num_dmat, outer_p_tuples, n_rule=n_rule)
@@ -1754,6 +1740,10 @@ write(*,*) 'all of loop done'
       already = contrib_cache_already_outer(len_cache, cache, num_dmat, outer_p_tuples)
    
    end if
+
+
+
+!   write(*,*) 'stage a'
    
    ! If an entry for these pert. tuples already exists in cache, then locate it
    ! and update the data there
@@ -1764,10 +1754,13 @@ write(*,*) 'all of loop done'
    
       do i = 1, len_cache
 
-         pstcmp = p_tuples_standardorder(cache(i)%num_dmat, &
-            cache(i)%p_tuples)
       
          if (cache(i)%num_dmat == num_dmat .AND. .NOT.(cache(i)%dummy_entry)) then
+
+         pstcmp = p_tuples_standardorder(cache(i)%num_dmat, &
+            cache(i)%p_tuples)
+
+
             found_element = p_tuples_compare(cache(i)%num_dmat, &
             pstcmp, p_tuples_st_order)
             
@@ -2103,7 +2096,7 @@ write(*,*) 'all of loop done'
       end if
    
    end do
-   
+
 end function
  
  ! FIXME: Definitely ll-to-array chgs needed for this routine 
@@ -2430,14 +2423,7 @@ end function
             deallocate(blk_arg_b)
             deallocate(blk_arg_a)
 
-            write(*,*) 'total num_pert', total_num_perturbations
-
             do j = 1, total_num_perturbations
-
-               write(*,*) 'j', j
-               write(*,*) 'indices', indices
-               write(*,*) 'i', i
-               write(*,*) 'pids curr contr', pids_current_contrib
 
 ! FIXME: UNSURE ABOUT NEXT LINE
 ! Will use just the regular index, but change back if this causes problems

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -1803,15 +1803,7 @@ module rsp_property_caching
       
       deallocate(cache)
       
-      write(*,*) 'len_cache arg is', len_cache
-      
-      write(*,*) 'cache size is', size(cache)
-      write(*,*) 'cache store is len', size(cache_store)
-      
-      
       allocate(cache(len_cache + 1))
-      
-      write(*,*) 'I allocated', len_cache + 1
       
       ! FIXME: May be necessary to copy element by element
       ! But I think that the default assignment method will work here

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -1493,7 +1493,7 @@ module rsp_property_caching
    current_element(1)%p_inner%pid = (/0/)
    current_element(1)%p_inner%freq = (/0.0/)
    
-   call contrib_cache_outer_allocate(current_element(1)%contribs_outer)
+  call contrib_cache_outer_allocate(current_element(1)%contribs_outer)
    
  end subroutine
 
@@ -1941,6 +1941,8 @@ module rsp_property_caching
       cache(len_cache + 1) = new_element(1)
       
       deallocate(cache_store)
+      
+      len_cache = len_cache + 1
       
       
    end if

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -41,8 +41,61 @@ module rsp_property_caching
   
  ! Define contrib cache datatypes
  
- ! "Outer" type: can be "independent" or attached to inner
+ ! New "outer" type
+ ! An instance of this is one cache entry to be used in array of such
  type contrib_cache_outer
+ 
+   logical :: dummy_entry
+   ! Number of chain rule applications
+   integer :: num_dmat
+   ! Perturbation tuples
+   type(p_tuple), allocatable, dimension(:) :: p_tuples
+   
+   integer :: contrib_type = 0
+   ! Choice of n rule for contribution (for use in two-factor terms)
+   integer :: n_rule = 0
+   ! Size of contribution data
+   integer :: contrib_size = 0
+   ! Perturbation block information
+   integer, allocatable, dimension(:) :: nblks_tuple
+   integer, allocatable, dimension(:,:) :: blk_sizes
+   integer, allocatable, dimension(:,:) :: indices
+   integer, allocatable, dimension(:,:,:) :: blks_tuple_info
+   integer, allocatable, dimension(:) :: blks_tuple_triang_size
+   ! Matrix data (if used)
+   type(QcMat), allocatable, dimension(:) :: data_mat 
+   ! Scalar data (if used)
+   complex(8), allocatable, dimension(:) :: data_scal
+ 
+ ! New "inner" type
+ 
+ ! "Inner" type: For use in e.g. perturbed Fock and energy-type terms
+ ! An instance of this is one cache entry to be used in array of such
+ ! Attaches to one or more outer cache instances
+ type contrib_cache
+
+   ! Perturbation tuple
+   type(p_tuple) :: p_inner
+
+   ! Number of outer cache instances attached to this inner
+   integer :: num_outer
+   ! Perturbation block/indices information
+   integer :: nblks
+   integer, allocatable, dimension(:) :: blk_sizes
+   integer :: blks_triang_size
+   integer, allocatable, dimension(:,:) :: blk_info
+   integer, allocatable, dimension(:,:) :: indices
+         
+   ! Associated outer cache instances
+   type(contrib_cache_outer_array), allocatable, dimension(:) :: contribs_outer
+
+ end type 
+ 
+ 
+ ! FIXME: OLD TYPES TO BE RMD
+ 
+ ! "Outer" type: can be "independent" or attached to inner
+ type contrib_cache_outer_old
 
    type(contrib_cache_outer), pointer :: next
    logical :: last
@@ -75,7 +128,7 @@ module rsp_property_caching
 
  ! "Inner" type: For use in e.g. perturbed Fock and energy-type terms
  ! Attaches to one or more outer cache instances
- type contrib_cache
+ type contrib_cache_old
 
    type(contrib_cache), pointer :: next
    logical :: last
@@ -95,6 +148,8 @@ module rsp_property_caching
    type(contrib_cache_outer), pointer :: contribs_outer
 
  end type 
+ 
+ ! END FIXME: OLD TYPES
 
  
  contains
@@ -106,6 +161,7 @@ module rsp_property_caching
   
  
  
+  ! FIXME: No ll-to-array chgs needed for this routine
     
   ! Initialize progress/restarting framework if dictated
   ! by restart flag r_flag
@@ -138,6 +194,8 @@ module rsp_property_caching
     end if
     
   end subroutine
+     
+  ! FIXME: No ll-to-array chgs needed for this routine     
      
   ! Check progress counter against restart checkpoint
   ! Return true if checkpoint not passed, false if passed
@@ -193,6 +251,7 @@ module rsp_property_caching
     
   end function
   
+  ! FIXME: No ll-to-array chgs needed for this routine
   
   ! Increment calculation progress counter prog_info at level 'lvl'
   ! and store in file if dictated by restarting setup flag r_flag 
@@ -222,6 +281,8 @@ module rsp_property_caching
     end if
     
   end subroutine
+ 
+! FIXME: Maybe ll-to-array chgs needed for this routine
  
  ! Store array of matrices or scalars in file fname
  subroutine mat_scal_store(array_size, fname, r_flag, mat, scal, start_pos)
@@ -285,6 +346,8 @@ module rsp_property_caching
  
  end subroutine
  
+ ! FIXME: Maybe ll-to-array chgs needed for this routine
+ 
  ! Retrieve array of matrices or scalars from file fname
  subroutine mat_scal_retrieve(array_size, fname, mat, scal)
  
@@ -325,6 +388,8 @@ module rsp_property_caching
     end if
  
  end subroutine
+ 
+ ! FIXME: Definitely ll-to-array chgs needed for this routine
  
  ! Store contribution cache structure (including outer attached instances) in file fname
  subroutine contrib_cache_store(cache, r_flag, fname)
@@ -504,6 +569,8 @@ module rsp_property_caching
  
  end subroutine
  
+ ! FIXME: Definitely ll-to-array chgs needed for this routine
+ 
  ! Retrieve contribution cache structure (including outer attached instances) from file fname
  subroutine contrib_cache_retrieve(cache, fname)
  
@@ -569,6 +636,8 @@ module rsp_property_caching
  
  end subroutine
  
+ ! FIXME: Definitely ll-to-array chgs needed for this routine
+ 
  ! Wrapper: Get one inner contribution cache instance from file fname
  subroutine contrib_cache_retrieve_one_inner(cache_new, fname, funit)
  
@@ -583,6 +652,8 @@ module rsp_property_caching
     call contrib_cache_read_one_inner(cache_new, fname, funit)
 
  end subroutine
+
+ ! FIXME: Definitely ll-to-array chgs needed for this routine 
  
  ! Read one inner contribution cache instance from file fname
  subroutine contrib_cache_read_one_inner(cache, fname, funit)
@@ -710,6 +781,8 @@ module rsp_property_caching
       read(funit) cache%indices
       
  end subroutine
+
+ ! FIXME: Definitely ll-to-array chgs needed for this routine 
  
  ! Wrapper: Store outer type contribution cache element in file fname
  subroutine contrib_cache_outer_store(cache, fname, r_flag, mat_acc_in)
@@ -746,6 +819,8 @@ module rsp_property_caching
  
  
  end subroutine
+
+ ! FIXME: Definitely ll-to-array chgs needed for this routine
  
  ! Write one outer contribution cache element to file fname
  ! Assumes file 'fname' is already opened with I/O unit 'funit'
@@ -977,6 +1052,10 @@ module rsp_property_caching
  
  
  end subroutine
+
+ ! FIXME: Definitely ll-to-array chgs needed for this routine 
+ ! Need to change to do first allocation here
+ ! Don't know what to do about mem mgr update yet
  
  ! Wrapper 1: Get outer contribution cache instance from file fname
  ! Add condition to handle "not from inner"
@@ -1052,6 +1131,7 @@ module rsp_property_caching
  
  end subroutine
  
+ ! FIXME: Definitely ll-to-array chgs needed for this routine
  
  ! Wrapper 2: Get one outer cache element from file fname
  subroutine contrib_cache_retrieve_one_outer(cache, fname, funit, mat_acc_in)
@@ -1081,6 +1161,8 @@ module rsp_property_caching
    end if
  
  end subroutine
+
+ ! FIXME: Definitely ll-to-array chgs needed for this routine 
  
  ! Read one outer contribution cache element from file fname
  subroutine contrib_cache_read_one_outer(cache, fname, funit, mat_acc_in)
@@ -1287,6 +1369,7 @@ module rsp_property_caching
    
  end subroutine
  
+ ! FIXME: Definitely ll-to-array chgs needed for this routine, maybe RM altogether
  
  ! Cycle outer instances attached to 'current_element' until specified
  ! element is reached
@@ -1364,6 +1447,8 @@ module rsp_property_caching
    
 
  end subroutine
+
+ ! FIXME: Definitely ll-to-array chgs needed for this routine, maybe RM altogether 
  
  ! Cycle contribution cache until first element reached
  function contrib_cache_cycle_first(current_element) result(next_element)
@@ -1383,6 +1468,8 @@ module rsp_property_caching
 
  end function
 
+ ! FIXME: Definitely ll-to-array chgs needed for this routine, maybe RM altogether 
+ 
  ! Cycle outer contribution cache element until first element reached
  function contrib_cache_outer_cycle_first(current_element) result(next_element)
 
@@ -1401,6 +1488,8 @@ module rsp_property_caching
 
  end function
  
+ ! FIXME: Definitely ll-to-array chgs needed for this routine, maybe RM altogether 
+ 
  ! Return next element in contribution cache linked list
  function contrib_cache_next_element(current_element) result(next_element)
 
@@ -1413,6 +1502,8 @@ module rsp_property_caching
 
  end function
 
+ ! FIXME: Definitely ll-to-array chgs needed for this routine, maybe RM altogether 
+ 
  ! Return next element in outer contribution cache linked list
  function contrib_cache_outer_next_element(current_element) result(next_element)
 
@@ -1424,6 +1515,8 @@ module rsp_property_caching
    next_element => current_element%next
 
  end function
+
+ ! FIXME: Definitely ll-to-array chgs needed for this routine 
  
   ! Cycle through a contribution cache and 
   ! deallocate any array-type data in it
@@ -1474,6 +1567,8 @@ module rsp_property_caching
    
   end subroutine
  
+
+ ! FIXME: Definitely ll-to-array chgs needed for this routine 
  
   ! Cycle through an outer contribution cache and 
   ! deallocate any array-type data in it
@@ -1563,6 +1658,7 @@ module rsp_property_caching
    
   end subroutine
  
+ ! FIXME: Definitely ll-to-array chgs needed for this routine
  
   ! Allocate and set up new contribution cache element
   subroutine contrib_cache_allocate(current_element)
@@ -1590,37 +1686,41 @@ module rsp_property_caching
    call contrib_cache_outer_allocate(current_element%contribs_outer)
    
  end subroutine
+
+ ! FIXME: Definitely ll-to-array chgs needed for this routine FIXME:UPD
  
- ! Allocate and set up new outer contribution cache element
+ ! Set up new outer contribution cache
+ ! This creates a one-entry cache with a dummy entry 
+ ! The cache can then later be extended
  subroutine contrib_cache_outer_allocate(current_element)
 
     implicit none
 
-    type(contrib_cache_outer), pointer :: current_element
-
-    allocate(current_element)
-
-    current_element%next => current_element
-    current_element%num_dmat = 0
-    current_element%last = .TRUE.
-    current_element%dummy_entry = .TRUE.
-
-    allocate(current_element%p_tuples(1))
-
-    current_element%p_tuples(1)%npert = 0
-
-    allocate(current_element%p_tuples(1)%pdim(1))
-    allocate(current_element%p_tuples(1)%plab(1))
-    allocate(current_element%p_tuples(1)%pid(1))
-    allocate(current_element%p_tuples(1)%freq(1))
+    type(contrib_cache_outer), allocatable, dimension(:) :: current_element
+    
+    allocate(current(element(1)))
+    
+    current_element(1)%dummy_entry = .TRUE.
+    current_element(1)%num_dmat = 0
         
-   current_element%p_tuples(1)%pdim = (/0/)
-   current_element%p_tuples(1)%plab = (/'NUTN'/)
-   current_element%p_tuples(1)%pid = (/0/)
-   current_element%p_tuples(1)%freq = (/0.0/)
+    allocate(current_element(1)%p_tuples(1))
+
+    current_element(1)%p_tuples(1)%npert = 0
+
+    allocate(current_element(1)%p_tuples(1)%pdim(1))
+    allocate(current_element(1)%p_tuples(1)%plab(1))
+    allocate(current_element(1)%p_tuples(1)%pid(1))
+    allocate(current_element(1)%p_tuples(1)%freq(1))
+        
+    current_element(1)%p_tuples(1)%pdim = (/0/)
+    current_element(1)%p_tuples(1)%plab = (/'NUTN'/)
+    current_element(1)%p_tuples(1)%pid = (/0/)
+    current_element(1)%p_tuples(1)%freq = (/0.0/)
 
   end subroutine
- 
+
+ ! FIXME: Definitely ll-to-array chgs needed for this routine  
+  
  ! Initialize contribution cache (and associated outer contribution cache)
  ! as specified by perturbation tuples 'p_tuples'
  subroutine contrib_cache_initialize(new_element, num_p_tuples, p_tuples, n_rule)
@@ -1691,7 +1791,9 @@ module rsp_property_caching
  end subroutine
  
  
- ! Initialize outer contribution cache as specified by perturbation tuples 'outer_p_tuples'
+ ! FIXME: Definitely ll-to-array chgs needed for this routine FIXME: UPD
+ 
+ ! Initialize outer contribution cache element as specified by perturbation tuples 'outer_p_tuples'
  ! 'unperturbed' flag signifies empty perturbation tuple (typically used for 'all inner' case)
  subroutine contrib_cache_outer_initialize(new_element, unperturbed, num_dmat, outer_p_tuples)
 
@@ -1703,7 +1805,6 @@ module rsp_property_caching
    type(p_tuple), dimension(num_dmat) :: outer_p_tuples
 
    new_element%num_dmat = num_dmat
-   new_element%last = .TRUE.
    new_element%dummy_entry = .FALSE.
    
    if (.NOT.(unperturbed)) then
@@ -1759,15 +1860,10 @@ module rsp_property_caching
    
       new_element%p_tuples%npert = 0
    
-      allocate(new_element%p_tuples(1)%pdim(1))
-      allocate(new_element%p_tuples(1)%plab(1))
-      allocate(new_element%p_tuples(1)%pid(1))
-      allocate(new_element%p_tuples(1)%freq(1))
-      
-      new_element%p_tuples(1)%pdim = (/0/)
-      new_element%p_tuples(1)%plab = (/'NUTN'/)
-      new_element%p_tuples(1)%pid = (/0/)
-      new_element%p_tuples(1)%freq = (/0.0/)
+      allocate(new_element%p_tuples(1)%pdim(0))
+      allocate(new_element%p_tuples(1)%plab(0))
+      allocate(new_element%p_tuples(1)%pid(0))
+      allocate(new_element%p_tuples(1)%freq(0))
       
       ! MaR: Creating indices for unperturbed entry: Return here if problems arise
       
@@ -1778,20 +1874,24 @@ module rsp_property_caching
       
  end subroutine
    
+
+ ! FIXME: Definitely ll-to-array chgs needed for this routine FIXME: UPD
    
- ! Add outer contribution cache element to existing linked list
- subroutine contrib_cache_outer_add_element(curr_element, unperturbed, num_dmat, &
+ ! Add new element to outer contribution cache
+ subroutine contrib_cache_outer_add_element(len_cache, cache, unperturbed, num_dmat, &
             outer_p_tuples, data_size, data_mat, data_scal, n_rule)
 
    implicit none
 
-   logical :: unperturbed, found_element, already
+   logical :: unperturbed, already, found_element
    integer :: num_dmat, i, j, passedlast
    integer, optional :: data_size, n_rule
-   type(contrib_cache_outer), target :: curr_element
-   type(contrib_cache_outer), pointer :: new_element
-   type(contrib_cache_outer), pointer :: new_element_ptr
-   type(contrib_cache_outer), pointer :: next_element
+   integer :: len_cache, found_loc
+   type(contrib_cache_outer), dimension(len_cache) :: cache
+   type(contrib_cache_outer), allocatable, dimension(:) :: cache_store
+   type(contrib_cache_outer) :: new_element
+  
+
    type(p_tuple), dimension(num_dmat) :: outer_p_tuples, p_tuples_st_order
    
    type(Qcmat), optional, dimension(*) :: data_mat
@@ -1799,63 +1899,61 @@ module rsp_property_caching
 
    if (present(n_rule)) then
    
-      already = contrib_cache_already_outer(curr_element, num_dmat, outer_p_tuples, n_rule=n_rule)
+      already = contrib_cache_already_outer(len_cache, cache, num_dmat, outer_p_tuples, n_rule=n_rule)
    
    else
    
-      already = contrib_cache_already_outer(curr_element, num_dmat, outer_p_tuples)
+      already = contrib_cache_already_outer(len_cache, cache, num_dmat, outer_p_tuples)
    
    end if
    
+   ! If an entry for these pert. tuples already exists in cache, then locate it
+   ! and update the data there
    if (already) then
    
-      next_element => curr_element
-      passedlast = 0
-      p_tuples_st_order = p_tuples_standardorder(num_dmat, outer_p_tuples)
       found_element = .FALSE.
-
-      do while ((passedlast < 2) .AND. (found_element .eqv. .FALSE.))
+      p_tuples_st_order = p_tuples_standardorder(num_dmat, outer_p_tuples)
+   
+      do i = 1, len_cache
       
-         next_element => next_element%next
-         
-         if (next_element%num_dmat == num_dmat .AND. .NOT.(next_element%dummy_entry)) then
-            found_element = p_tuples_compare(next_element%num_dmat, &
-            p_tuples_standardorder(next_element%num_dmat, &
-            next_element%p_tuples), p_tuples_st_order)
+         if (cache(i)%num_dmat == num_dmat .AND. .NOT.(cache(i)%dummy_entry)) then
+            found_element = p_tuples_compare(cache(i)%num_dmat, &
+            p_tuples_standardorder(cache(i)%num_dmat, &
+            cache(i)%p_tuples), p_tuples_st_order)
+            
+            if (found_element .EQUIV. .TRUE.) then
+               found_loc = i
+               exit
+            end if
+            
          end if
             
-         if (next_element%last .eqv. .TRUE.) then
-            passedlast = passedlast + 1
-         end if
-
       end do
-      
+   
+      ! Update matrix data
       if(present(data_mat)) then
       
          do i = 1, data_size
          
-            call QcMatAEqB(next_element%data_mat(i),  data_mat(i))
+            call QcMatAEqB(cache(found_loc)%data_mat(i), data_mat(i))
            
          end do
    
       end if
    
+      ! Update scalar data: Currently not used
       if (present(data_scal)) then
    
       end if
-      
    
+   ! Otherwise, if an entry doesn't exist, then make a new entry in the cache
    else
    
-      next_element => curr_element
-      allocate(new_element)
+      ! Create the new entry
       call contrib_cache_outer_initialize(new_element, unperturbed, num_dmat, outer_p_tuples)
       new_element_ptr => new_element
    
-      do while (next_element%last .eqv. .FALSE.)
-         next_element => contrib_cache_outer_next_element(next_element)
-      end do
-   
+      ! Fill it with data if provided  
       if(present(data_mat)) then
       
          if (.NOT.(allocated(new_element%data_mat))) then
@@ -1874,6 +1972,7 @@ module rsp_property_caching
    
       end if
    
+      ! Scalar data not presently used in this part of the code
       if (present(data_scal)) then
    
       end if
@@ -1884,13 +1983,28 @@ module rsp_property_caching
       
       end if
 
-      next_element%last = .FALSE.
-      new_element%next => next_element%next
-      next_element%next => new_element
+      allocate(cache_store(len_cache))
+      
+      ! FIXME: May be necessary to copy element by element
+      ! But I think that the default assignment method will work here
+      cache_store = cache
+      
+      deallocate(cache)
+      
+      allocate(cache(len_cache + 1))
+      
+      ! FIXME: May be necessary to copy element by element
+      ! But I think that the default assignment method will work here
+      cache(1:len_cache) = cache_store
+      cache(len_cache + 1) = new_element
+      
+      deallocate(cache_store)
    
    end if
       
  end subroutine
+ 
+ ! FIXME: Definitely ll-to-array chgs needed for this routine 
  
  ! Add contribution cache element to existing linked list
  subroutine contrib_cache_add_element(current_element, num_p_tuples, p_tuples, n_rule)
@@ -1999,6 +2113,8 @@ module rsp_property_caching
 
  end subroutine
  
+ ! FIXME: Definitely ll-to-array chgs needed for this routine 
+ 
  ! Check if element (inner + outer combination) as specified by 'p_tuples' (and possible 'n_rule')
  ! already exists in cache
  function contrib_cache_already(current_element, num_p_tuples, p_tuples, n_rule)
@@ -2074,56 +2190,47 @@ module rsp_property_caching
 
  end function
  
- 
+ ! FIXME: Definitely ll-to-array chgs needed for this routine 
+  
  ! Check if element of outer contribution cache as specified by 'p_tuples_outer'
  ! (and possible 'n_rule') exists in linked list
- function contrib_cache_already_outer(current_element, num_dmat, p_tuples_outer, n_rule)
+ function contrib_cache_already_outer(len_cache, cache, num_dmat, p_tuples_outer, n_rule)
 
    implicit none
 
    logical :: contrib_cache_already_outer
    integer :: passedlast, passedlast_outer, num_dmat, i
+   integer :: len_cache
    integer, optional :: n_rule
-   type(contrib_cache_outer), target :: current_element
-   type(contrib_cache_outer), pointer :: next_element
+   type(contrib_cache_outer), dimension(len_cache) :: cache
+   
    type(p_tuple), dimension(num_dmat) :: p_tuples_outer, p_tuples_ord
    
-   next_element => current_element
-   passedlast = 0
-
    p_tuples_ord = p_tuples_standardorder(num_dmat, p_tuples_outer)
 
    contrib_cache_already_outer = .FALSE.
 
-   ! NOTE (MaR): WHILE LOOP POTENTIALLY NON-TERMINATING
-   ! COULD THIS BE DONE IN ANOTHER WAY?
-   do while ((passedlast < 2) .AND. (contrib_cache_already_outer .eqv. .FALSE.))
-
-   ! Make sure the tuples that need to be ordered are ordered
+   do i = 1, len_cache
    
-      next_element => contrib_cache_outer_next_element(next_element)
-      
-      if (next_element%num_dmat == num_dmat .AND. .NOT.(next_element%dummy_entry)) then
+      if (cache(i)%num_dmat == num_dmat .AND. .NOT.(cache(i)%dummy_entry)) then
       
          contrib_cache_already_outer = p_tuples_compare(num_dmat, &
-                                       next_element%p_tuples, p_tuples_ord)
+                                       cache(i)%p_tuples, p_tuples_ord)
                                     
          if (present(n_rule)) then
       
-            contrib_cache_already_outer = contrib_cache_already_outer .AND. (n_rule == next_element%n_rule)
+            contrib_cache_already_outer = contrib_cache_already_outer .AND. (n_rule == cache(i)%n_rule)
 
          end if
          
                                  
       end if
-
-      if (next_element%last .eqv. .TRUE.) then
-         passedlast = passedlast + 1
-      end if
-
+   
    end do
-
- end function
+   
+end function
+ 
+ ! FIXME: Definitely ll-to-array chgs needed for this routine 
 
  ! Check if contribution cache (inner only) element (as specified by 'p_inner') 
  ! already exists in linked list 
@@ -2159,6 +2266,8 @@ module rsp_property_caching
    end do
 
  end function
+ 
+ ! FIXME: Definitely ll-to-array chgs needed for this routine 
  
  ! Get data from outer contribution cache element    
  subroutine contrib_cache_getdata_outer(cache, num_p_tuples, p_tuples, &
@@ -2515,6 +2624,8 @@ module rsp_property_caching
     end if
 
  end subroutine
+ 
+ ! FIXME: Definitely ll-to-array chgs needed for this routine
  
  ! Get data from contribution cache
  ! Will search linked list for appropriate inner entry, then


### PR DESCRIPTION


## Description

The linked list functionality for caching has been rewritten to use resizable arrays in place of a "pointer-based" linked list structure. I have for now disabled the restarting functionality but it's commented out and can be reinstated with some further work to adapt it to this new caching style (I know, commented-out code is not so great).

In most files, I have removed most or all use of array constructors in arguments to routines or functions and instead constructed the same arguments outside the context of the call itself. Such arguments have frequently been put into generically named variables. This change has been done in order to allow inside the routines called to modify or store the arguments that are used, e.g. for caching purposes. This seems to have been OK to do even with the array constructors for GNU compilers, but may have caused problems with Intel/MPI.

Finally there are some other minor bugfixes, some or all of which for bugs may have been introduced during the changes described above, so in those cases no "net bugfixing" over what is in master before this PR.

## Motivation and Context

This chance should allow OpenRSP to be run properly also when compiled in an Intel/MPI setup. It fixes the LSDalton issue https://gitlab.com/dalton/lsdalton/issues/35 .

## How Has This Been Tested?

I ran OpenRSP's unit test in an Intel/OpenMPI setup and I ran the LSDalton integration tests of OpenRSP in Intel/OpenMPI and Intel/Intel MPI setups. All attempted tests pass except possibly using "release" build setup of LSDalton with Intel/Intel MPI. But when building this latter again in relase mode with -fbacktrace and -g3 compiler flags added, the tests pass again.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) 
Breaking change: Restarting functionality for now disabled.

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go
