### PR TITLE
Reinstate restarting functionality after earlier caching structure rewrite

### DIFF
--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -1853,6 +1853,10 @@ module rsp_general
    
     allocate(outer_contract_sizes_1(cache%num_outer))
     allocate(outer_contract_sizes_2(cache%num_outer,2))
+    
+    outer_contract_sizes_1 = 0
+    outer_contract_sizes_2 = 0
+    
    
     ! Traversal: Find number of density matrices for contraction for nuc-nuc, 1-el, 2-el cases
     
@@ -1902,6 +1906,7 @@ module rsp_general
           num_1 = num_1 + 1
        
           outer_contract_sizes_1(k) = cache%contribs_outer(m)%blks_tuple_triang_size(1)
+         
           outer_contract_sizes_2(k, :) = &
           (/cache%contribs_outer(m)%blks_tuple_triang_size(1),1/)
           
@@ -2101,7 +2106,7 @@ module rsp_general
              call out_print(out_str, 1)
              write(out_str, *) ' '
              call out_print(out_str, 1)
-          
+             
              call get_1el_exp(num_pert, pert_ext, msize, &
                               LHS_dmat_1, cache%blks_triang_size*msize, &
                               contrib_1( (mcurr - 1) * cache%blks_triang_size + 1: &
@@ -2120,7 +2125,7 @@ module rsp_general
       !                                 (mcurr + msize - 1) * cache%blks_triang_size)
        
        
-             write(out_str, *) 'First-order density matrix-dependent contribution (sample)', &
+              write(out_str, *) 'First-order density matrix-dependent contribution (sample)', &
              contrib_1(1:min(10,size(contrib_1)))
              call out_print(out_str, 2)
               
@@ -2212,7 +2217,7 @@ module rsp_general
           
              ! Can the whole pair be done?
              if (curr_remain >= outer_contract_sizes_2(i, 1) + outer_contract_sizes_2(i, 2)) then
-                          
+             
                 ! If yes, add to workload
                 curr_remain = curr_remain - (outer_contract_sizes_2(i, 1) + &
                                              outer_contract_sizes_2(i, 2))
@@ -2442,7 +2447,7 @@ module rsp_general
           ! Traverse outer elements and fetch matrices
           
           do i = curr_pickup(1), next_pickup(1) - 1
-
+          
              if (.NOT.(mem_mgr%calibrate)) then
           
                 ! No chain rule applications

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -561,10 +561,15 @@ module rsp_general
           write(out_str, *) ' '
           call out_print(out_str, 1)
 
-
-!           call contrib_cache_outer_retrieve(S, 'OPENRSP_S_CACHE', .FALSE.)
-!           call contrib_cache_outer_retrieve(D, 'OPENRSP_D_CACHE', .FALSE.)
-!           call contrib_cache_outer_retrieve(F, 'OPENRSP_F_CACHE', .FALSE.)
+          ! CONTINUE HERE, HERA AND LATER CACHE SIZES NOT TRIVIAL, ESPECIALLY IF RETRIEVED, NEED 
+          ! TO CHG ARGUMENTS TO LATER MAIN ROUTINES
+          
+           allocate(S(0))
+           allocate(D(0))
+           allocate(F(0))
+           call contrib_cache_outer_retrieve(S, 'OPENRSP_S_CACHE', .FALSE.)
+           call contrib_cache_outer_retrieve(D, 'OPENRSP_D_CACHE', .FALSE.)
+           call contrib_cache_outer_retrieve(F, 'OPENRSP_F_CACHE', .FALSE.)
           
           if (residue_order > 0) then
        

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -596,8 +596,8 @@ module rsp_general
          
          if (residue_order > 0) then
 
-    call QcMatInit(Xf_unpert_arr(1))
-    call QcMatAEqB(Xf_unpert_arr(1), Xf_unpert(1))    
+             call QcMatInit(Xf_unpert_arr(1))
+             call QcMatAEqB(Xf_unpert_arr(1), Xf_unpert(1))    
        
              call contrib_cache_outer_allocate(Xf)
              xf_was_allocated = .TRUE.

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -4551,16 +4551,8 @@ module rsp_general
     deallocate(o_supsize)
     deallocate(o_supsize_prime)
     deallocate(o_size)
-    
-    
-    
-    
+
   end subroutine
-  
-  
-  
-  
-  
 
   ! Print tensors recursively
   recursive subroutine print_rsp_tensor(npert, lvl, pdim, prop, offset)

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -605,25 +605,6 @@ module rsp_perturbed_sdf
                    
                 end do
                 
-                
-                                write(*, *) 'Getting lower-order Fock matrix contribution from cache:'
-             
-                do i = 1, num_p_tuples
-                
-                   if (i == 1) then
-
-                      write(*, *) 'F', p_tuples(i)%plab
-
-          
-                   else
-                   
-                      write(*, *) 'D', p_tuples(i)%plab
- 
-                      
-                   end if
-                   
-                end do
-                
                 call contrib_cache_getdata(len_lof_cache, fock_lowerorder_cache, &
                 num_p_tuples, p_tuples, contrib_size=fp_size, ind_len=0, mat=Fp)
              

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -22,7 +22,7 @@ module rsp_perturbed_sdf
   contains
     
   ! Main routine for managing calculation of perturbed Fock, density and overlap matrices
-  subroutine rsp_fds(n_props, n_freq_cfgs, p_tuples, kn_rule, len_sdf, F, D, S, get_rsp_sol, get_ovl_mat, &
+  subroutine rsp_fds(n_props, n_freq_cfgs, p_tuples, kn_rule, F, D, S, get_rsp_sol, get_ovl_mat, &
                                get_1el_mat, get_2el_mat, get_xc_mat, out_print, dryrun, &
                                prog_info, rs_info, r_flag, sdf_retrieved, mem_mgr, Xf)
 
@@ -43,7 +43,7 @@ module rsp_perturbed_sdf
     integer :: r_flag
     integer :: c_ord
     integer :: len_curr_outer, len_d, len_lof_cache
-    integer :: len_cache, len_sdf
+    integer :: len_cache
     integer, allocatable, dimension(:) :: size_i
     type(QcMat), dimension(1) :: Fp_dum
     type(contrib_cache_outer), allocatable, dimension(:) :: F, D, S

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -240,7 +240,7 @@ module rsp_perturbed_sdf
           
              call contrib_cache_retrieve(lof_cache, 'OPENRSP_LOF_CACHE')
              lof_retrieved = .TRUE.
-             
+
           end if
        
        
@@ -251,7 +251,7 @@ module rsp_perturbed_sdf
           len_lof_cache = size(lof_cache)
        
           do m = 1, len_lof_cache
-       
+          
              ! Check if this stage passed previously and if so, then retrieve and skip execution
              if (rs_check(prog_info, rs_info, r_flag, lvl=3)) then
              
@@ -604,7 +604,26 @@ module rsp_perturbed_sdf
                    end if
                    
                 end do
+                
+                
+                                write(*, *) 'Getting lower-order Fock matrix contribution from cache:'
              
+                do i = 1, num_p_tuples
+                
+                   if (i == 1) then
+
+                      write(*, *) 'F', p_tuples(i)%plab
+
+          
+                   else
+                   
+                      write(*, *) 'D', p_tuples(i)%plab
+ 
+                      
+                   end if
+                   
+                end do
+                
                 call contrib_cache_getdata(len_lof_cache, fock_lowerorder_cache, &
                 num_p_tuples, p_tuples, contrib_size=fp_size, ind_len=0, mat=Fp)
              
@@ -2660,7 +2679,6 @@ module rsp_perturbed_sdf
 
     end if
     
-    
     ! Make the unperturbed D the first elements of the dmat holder array
     
     if (.NOT.(mem_mgr%calibrate)) then
@@ -2737,7 +2755,6 @@ module rsp_perturbed_sdf
                               1, ind_len=size(curr_dmat_indices, 2), &
                               ind_unsorted=int_arg, &
                               mat_sing=dmat_total_array(dmat_array_ctr))
-
 
                 deallocate(int_arg)
                 deallocate(pert_arg)

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -87,8 +87,7 @@ module rsp_perturbed_sdf
        write(out_str, *) ' '
        call out_print(out_str, 1)
           
-!        allocate(cache)
-!        call contrib_cache_retrieve(cache, 'OPENRSP_FDS_ID')
+       call contrib_cache_retrieve(cache, 'OPENRSP_FDS_ID')
        lof_retrieved = .TRUE.
              
     else
@@ -110,7 +109,8 @@ module rsp_perturbed_sdf
           end do
        end do
 
-!        call contrib_cache_store(cache, r_flag, 'OPENRSP_FDS_ID')
+       len_cache = size(cache)
+       call contrib_cache_store(len_cache, cache, r_flag, 'OPENRSP_FDS_ID')
        
     end if
 
@@ -172,7 +172,7 @@ module rsp_perturbed_sdf
        
           if (.NOT.(lof_retrieved)) then
           
-!              call contrib_cache_retrieve(lof_cache, 'OPENRSP_LOF_CACHE')
+             call contrib_cache_retrieve(lof_cache, 'OPENRSP_LOF_CACHE')
              lof_retrieved = .TRUE.
              
           end if
@@ -215,8 +215,9 @@ module rsp_perturbed_sdf
              k = k + 1
        
           end do
-          
-!           call contrib_cache_store(lof_cache, r_flag, 'OPENRSP_LOF_CACHE')
+
+            len_lof_cache = size(lof_cache)
+            call contrib_cache_store(len_lof_cache, lof_cache, r_flag, 'OPENRSP_LOF_CACHE')
        
        end if
        
@@ -237,7 +238,7 @@ module rsp_perturbed_sdf
                     
           if (.NOT.(lof_retrieved)) then
           
-!              call contrib_cache_retrieve(lof_cache, 'OPENRSP_LOF_CACHE')
+             call contrib_cache_retrieve(lof_cache, 'OPENRSP_LOF_CACHE')
              lof_retrieved = .TRUE.
              
           end if
@@ -282,11 +283,10 @@ module rsp_perturbed_sdf
                 
                 if (.NOT.(mem_mgr%calibrate)) then
                 
-!                    call contrib_cache_store(lof_cache, r_flag, 'OPENRSP_LOF_CACHE')
+                   len_lof_cache = size(lof_cache)
+                   call contrib_cache_store(len_lof_cache, lof_cache, r_flag, 'OPENRSP_LOF_CACHE')
                    
                 end if
-                
-                 
                 
              end if
                       
@@ -300,7 +300,6 @@ module rsp_perturbed_sdf
        ! Set 'retrieved' flag to false: If retrieved at current order, state should now 
        ! be as if not restarted (i.e. as if calculated in present run)
        lof_retrieved = .FALSE.
-
       
        ! Check if this stage passed previously and if so, then retrieve and skip execution
        call prog_incr(prog_info, r_flag, 2)
@@ -319,13 +318,13 @@ module rsp_perturbed_sdf
           
           if (.NOT.(sdf_retrieved)) then
           
-!              call contrib_cache_outer_retrieve(S, 'OPENRSP_S_CACHE', .FALSE.)
-!              call contrib_cache_outer_retrieve(D, 'OPENRSP_D_CACHE', .FALSE.)
-!              call contrib_cache_outer_retrieve(F, 'OPENRSP_F_CACHE', .FALSE.)
+             call contrib_cache_outer_retrieve(S, 'OPENRSP_S_CACHE')
+             call contrib_cache_outer_retrieve(D, 'OPENRSP_D_CACHE')
+             call contrib_cache_outer_retrieve(F, 'OPENRSP_F_CACHE')
              
              if (present(Xf)) then
        
-!              call contrib_cache_outer_retrieve(Xf, 'OPENRSP_Xf_CACHE', .FALSE.)
+                call contrib_cache_outer_retrieve(Xf, 'OPENRSP_Xf_CACHE')
           
              end if
                        
@@ -370,11 +369,9 @@ module rsp_perturbed_sdf
           
           if (.NOT.(mem_mgr%calibrate)) then
           
-             len_d = size(D)
-          
-!              call contrib_cache_outer_store(len_d, S, 'OPENRSP_S_CACHE', r_flag)
-!              call contrib_cache_outer_store(len_d, D, 'OPENRSP_D_CACHE', r_flag)
-!              call contrib_cache_outer_store(len_d, F, 'OPENRSP_F_CACHE', r_flag)
+             call contrib_cache_outer_store(size(S), S, 'OPENRSP_S_CACHE', r_flag)
+             call contrib_cache_outer_store(size(D), D, 'OPENRSP_D_CACHE', r_flag)
+             call contrib_cache_outer_store(size(F), F, 'OPENRSP_F_CACHE', r_flag)
              
           end if
        
@@ -1935,7 +1932,7 @@ module rsp_perturbed_sdf
                       write(out_str, *) ' '
                       call out_print(out_str, 2)
                    
-!                       call mat_scal_retrieve(rs_info(3), 'OPENRSP_MAT_RSP', mat=X(1:rs_info(3)))
+                      call mat_scal_retrieve(rs_info(3), 'OPENRSP_MAT_RSP', mat=X(1:rs_info(3)))
                       rsp_eqn_retrieved = .TRUE.
                       
              
@@ -1988,8 +1985,8 @@ module rsp_perturbed_sdf
   
                       end if
                   
-!                       call mat_scal_store(last - first + 1, 'OPENRSP_MAT_RSP', r_flag, &
-!                            mat=X(ind_ctr+first-1:ind_ctr+last-1), start_pos = ind_ctr+first-1)
+                      call mat_scal_store(last - first + 1, 'OPENRSP_MAT_RSP', r_flag, &
+                           mat=X(ind_ctr+first-1:ind_ctr+last-1), start_pos = ind_ctr+first-1)
                     
                    end if
                    
@@ -2015,7 +2012,7 @@ module rsp_perturbed_sdf
          
              if (.NOT.(rsp_eqn_retrieved)) then
           
-!                 call mat_scal_retrieve(rs_info(3), 'OPENRSP_MAT_RSP', mat=X(1:rs_info(3)))
+                call mat_scal_retrieve(rs_info(3), 'OPENRSP_MAT_RSP', mat=X(1:rs_info(3)))
                 rsp_eqn_retrieved = .TRUE.
              
              end if
@@ -2056,8 +2053,8 @@ module rsp_perturbed_sdf
                 deallocate(arg_int_b)
                 deallocate(arg_int)
 
-!                 call mat_scal_store(size_i(k), 'OPENRSP_MAT_RSP', r_flag, &
-!                            mat=X(ind_ctr:ind_ctr+size_i(k)-1), start_pos = ind_ctr)
+                call mat_scal_store(size_i(k), 'OPENRSP_MAT_RSP', r_flag, &
+                           mat=X(ind_ctr:ind_ctr+size_i(k)-1), start_pos = ind_ctr)
                            
              end if
                    

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -353,8 +353,6 @@ module rsp_property_caching
    
       end do
 
-      write(*,*) 'I found', n_mpt, 'elems in this len', num_entries, 'cache'
-      
       write(funit) num_entries - n_mpt
    
       ! Traverse and store
@@ -448,7 +446,6 @@ module rsp_property_caching
       
          write(funit) size(cache(i)%contribs_outer)
          
-         
          write(funit) cache(i)%nblks
       
          write(funit) size(cache(i)%blk_sizes)
@@ -531,13 +528,19 @@ module rsp_property_caching
       call contrib_cache_read_one_inner(cache(i + 1), fname, funit)
       
       allocate(cache(i + 1)%contribs_outer(cache(i + 1)%num_outer))
-     
+    
       do j = 1, cache(i + 1)%num_outer
      
          call contrib_cache_read_one_outer(cache(i + 1)%contribs_outer(j), fname, &
               funit, mat_acc_in=mat_acc)
       
       end do
+      
+      ! Since I wrote it with one more outer element (maybe because of dummy)
+      ! I now need to decrease the number of outer by one to get the "acceptable"
+      ! number of outer entries which avoids indexing issues, due to idiosyncrasies 
+      ! of the current setup
+      cache(i + 1)%num_outer = cache(i + 1)%num_outer - 1
    
    end do
 
@@ -2262,10 +2265,6 @@ end function
             end if
             
             if (present(mat)) then
-            
-                write(*,*) 'cache, res offs', cache_offset + &
-                               cache_hard_offset, res_offset
-                write(*,*) 'sizes', size(cache(loc_found)%data_mat), size(mat)
             
                call QcMatRAXPY(1.0d0, cache(loc_found)%data_mat(cache_offset + &
                                cache_hard_offset), mat(res_offset))

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -93,67 +93,6 @@ module rsp_property_caching
 
  end type 
  
- 
- ! FIXME: OLD TYPES TO BE RMD
- 
-!  ! "Outer" type: can be "independent" or attached to inner
-!  type contrib_cache_outer_old
-! 
-!    type(contrib_cache_outer), pointer :: next
-!    logical :: last
-!    logical :: dummy_entry
-!    ! Number of chain rule applications
-!    integer :: num_dmat
-!    ! Perturbation tuples
-!    type(p_tuple), allocatable, dimension(:) :: p_tuples
-! 
-!    ! Contribution type for two-factor terms: 1: Only Pulay n, 
-!    ! 3: Only Lagrange, 4: Both Pulay and Lagrange
-!    integer :: contrib_type = 0
-!    
-!    ! Choice of n rule for contribution (for use in two-factor terms)
-!    integer :: n_rule = 0
-!    ! Size of contribution data
-!    integer :: contrib_size = 0
-!    ! Perturbation block information
-!    integer, allocatable, dimension(:) :: nblks_tuple
-!    integer, allocatable, dimension(:,:) :: blk_sizes
-!    integer, allocatable, dimension(:,:) :: indices
-!    integer, allocatable, dimension(:,:,:) :: blks_tuple_info
-!    integer, allocatable, dimension(:) :: blks_tuple_triang_size
-!    ! Matrix data (if used)
-!    type(QcMat), allocatable, dimension(:) :: data_mat 
-!    ! Scalar data (if used)
-!    complex(8), allocatable, dimension(:) :: data_scal
-! 
-!  end type 
-! 
-!  ! "Inner" type: For use in e.g. perturbed Fock and energy-type terms
-!  ! Attaches to one or more outer cache instances
-!  type contrib_cache_old
-! 
-!    type(contrib_cache), pointer :: next
-!    logical :: last
-!    ! Perturbation tuple
-!    type(p_tuple) :: p_inner
-! 
-!    ! Number of outer cache instances attached to this inner
-!    integer :: num_outer
-!    ! Perturbation block/indices information
-!    integer :: nblks
-!    integer, allocatable, dimension(:) :: blk_sizes
-!    integer :: blks_triang_size
-!    integer, allocatable, dimension(:,:) :: blk_info
-!    integer, allocatable, dimension(:,:) :: indices
-!          
-!    ! Pointer to attached outer cache instances
-!    type(contrib_cache_outer), pointer :: contribs_outer
-! 
-!  end type 
- 
- ! END FIXME: OLD TYPES
-
- 
  contains
     
   ! Initialize progress/restarting framework if dictated

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -394,163 +394,131 @@ module rsp_property_caching
       
    else if (r_flag == 3) then
 
-! Old LL functionality: Rewrite together with retrieve routine into array form   
+   ! Old LL functionality: Rewrite together with retrieve routine into array form   
    
-!       mat_acc = 0
-!  
-!       funit = 260
-!  
-!       open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
-!         form='unformatted', status='replace', action='write')
-!    
-!       ! Cycle to start
-!       cache_next => cache
-!       do while(.NOT.(cache_next%last))
-!          cache_next => cache_next%next
-!       end do
-!       cache_next => cache_next%next
-!       cache_next => cache_next%next
-!    
-!       num_entries = 0
-!    
-!       ! Traverse to get number of entries
-!       termination = .FALSE.
-!       do while(.NOT.(termination))
-!    
-!          num_entries = num_entries + 1
-!    
-!          termination = cache_next%last
-!          cache_next => cache_next%next
-!    
-!       end do
-!    
-!       write(funit) num_entries
-!    
-!       ! Cycle to start
-!       do while(.NOT.(cache_next%last))
-!          cache_next => cache_next%next
-!       end do
-!       cache_next => cache_next%next
-!       cache_next => cache_next%next
-!    
-!       
-!       ! Traverse and store
-!       termination = .FALSE.
-!       do i = 1, num_entries
-!    
-!          write(funit) cache_next%last
-!          write(funit) cache_next%p_inner%npert
-!          do j = 1, cache_next%p_inner%npert
-!       
-!             write(funit) cache_next%p_inner%pdim(j)
-!             write(funit) cache_next%p_inner%plab(j)
-!             write(funit) cache_next%p_inner%pid(j)
-!             write(funit) cache_next%p_inner%freq(j)
-!       
-!          end do
-!       
-!          ! MaR: New code for residue handling
-!       
-!          write(funit) cache_next%p_inner%do_residues
-!          write(funit) cache_next%p_inner%n_pert_res_max
-!          write(funit) cache_next%p_inner%n_states
-!       
-!          if (cache_next%p_inner%do_residues > 0) then
-!       
-!             if (allocated(cache_next%p_inner%states)) then
-!          
-!                write(funit) .TRUE.
-!                write(funit) size(cache_next%p_inner%states)
-!          
-!                do j = 1, size(cache_next%p_inner%states)
-!          
-!                   write(funit) cache_next%p_inner%states(j)
-!                
-!                end do
-!             
-!             else
-!          
-!                write(funit) .FALSE.
-!          
-!             end if
-!          
-!             if (allocated(cache_next%p_inner%exenerg)) then
-!          
-!                write(funit) .TRUE.
-!                write(funit) size(cache_next%p_inner%exenerg)
-!          
-!                do j = 1, size(cache_next%p_inner%exenerg)
-!          
-!                   write(funit) cache_next%p_inner%exenerg(j)
-!                
-!                end do
-!             
-!             else
-!          
-!                write(funit) .FALSE.
-!          
-!             end if
-!          
-!          
-!             if (allocated(cache_next%p_inner%part_of_residue)) then
-!          
-!                write(funit) .TRUE.
-!                write(funit) size(cache_next%p_inner%part_of_residue, 1)
-!                write(funit) size(cache_next%p_inner%part_of_residue, 2)
-!          
-!                do j = 1, size(cache_next%p_inner%part_of_residue, 1)
-!             
-!                   do k = 1, size(cache_next%p_inner%part_of_residue, 2)
-!          
-!                      write(funit) cache_next%p_inner%part_of_residue(j, k)
-!                   
-!                   end do
-!                
-!                end do
-!             
-!             else
-!          
-!                write(funit) .FALSE.
-!          
-!             end if
-!          
-!          end if
-!       
-!       
-!          ! End new
-!       
-!       
-!          write(funit) cache_next%num_outer
-!          write(funit) cache_next%nblks
-!       
-!          write(funit) size(cache_next%blk_sizes)
-!          write(funit) cache_next%blk_sizes
-!       
-!          write(funit) cache_next%blks_triang_size
-! 
-!          write(funit) size(cache_next%blk_info, 1)
-!          write(funit) size(cache_next%blk_info, 2)
-!          write(funit) cache_next%blk_info
-!      
-!          write(funit) size(cache_next%indices, 1)
-!          write(funit) size(cache_next%indices, 2)
-!          write(funit) cache_next%indices
-!       
-!          
-!       
-!          outer_next => cache_next%contribs_outer
-!       
-!          ! num_outer may not be well-defined; consider 
-!          ! switching to traversal with termination instead
-!          
-!          call contrib_cache_outer_put(outer_next, fname, funit, mat_acc_in=mat_acc)
-!    
-!          cache_next => cache_next%next
-!    
-!       end do
-! 
-!       close(funit)
-!  
+      mat_acc = 0
+ 
+      funit = 260
+ 
+      open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
+        form='unformatted', status='replace', action='write')
+   
+   
+      num_entries = len_cache
+
+      write(funit) num_entries
+   
+     
+      ! Traverse and store
+      termination = .FALSE.
+      do i = 1, num_entries
+   
+         write(funit) cache(i)%p_inner%npert
+         do j = 1, cache(i)%p_inner%npert
+      
+            write(funit) cache(i)%p_inner%pdim(j)
+            write(funit) cache(i)%p_inner%plab(j)
+            write(funit) cache(i)%p_inner%pid(j)
+            write(funit) cache(i)%p_inner%freq(j)
+      
+         end do
+      
+         ! MaR: New code for residue handling
+      
+         write(funit) cache(i)%p_inner%do_residues
+         write(funit) cache(i)%p_inner%n_pert_res_max
+         write(funit) cache(i)%p_inner%n_states
+      
+         if (cache(i)%p_inner%do_residues > 0) then
+      
+            if (allocated(cache(i)%p_inner%states)) then
+         
+               write(funit) .TRUE.
+               write(funit) size(cache(i)%p_inner%states)
+         
+               do j = 1, size(cache(i)%p_inner%states)
+         
+                  write(funit) cache(i)%p_inner%states(j)
+               
+               end do
+            
+            else
+         
+               write(funit) .FALSE.
+         
+            end if
+         
+            if (allocated(cache(i)%p_inner%exenerg)) then
+         
+               write(funit) .TRUE.
+               write(funit) size(cache(i)%p_inner%exenerg)
+         
+               do j = 1, size(cache(i)%p_inner%exenerg)
+         
+                  write(funit) cache(i)%p_inner%exenerg(j)
+               
+               end do
+            
+            else
+         
+               write(funit) .FALSE.
+         
+            end if
+         
+         
+            if (allocated(cache(i)%p_inner%part_of_residue)) then
+         
+               write(funit) .TRUE.
+               write(funit) size(cache(i)%p_inner%part_of_residue, 1)
+               write(funit) size(cache(i)%p_inner%part_of_residue, 2)
+         
+               do j = 1, size(cache(i)%p_inner%part_of_residue, 1)
+            
+                  do k = 1, size(cache(i)%p_inner%part_of_residue, 2)
+         
+                     write(funit) cache(i)%p_inner%part_of_residue(j, k)
+                  
+                  end do
+               
+               end do
+            
+            else
+         
+               write(funit) .FALSE.
+         
+            end if
+         
+         end if
+      
+      
+         ! End new
+      
+      
+         write(funit) cache(i)%num_outer
+         write(funit) cache(i)%nblks
+      
+         write(funit) size(cache(i)%blk_sizes)
+         write(funit) cache(i)%blk_sizes
+      
+         write(funit) cache(i)%blks_triang_size
+
+         write(funit) size(cache(i)%blk_info, 1)
+         write(funit) size(cache(i)%blk_info, 2)
+         write(funit) cache(i)%blk_info
+     
+         write(funit) size(cache(i)%indices, 1)
+         write(funit) size(cache(i)%indices, 2)
+         write(funit) cache(i)%indices
+      
+         
+         call contrib_cache_outer_put(size(cache_next%contribs_outer), 
+              cache_next%contribs_outer, fname, funit, mat_acc_in=mat_acc)
+   
+   
+      end do
+
+      close(funit)
+
    end if
  
  end subroutine
@@ -772,8 +740,6 @@ module rsp_property_caching
       
  end subroutine
 
- ! FIXME: Definitely ll-to-array chgs needed for this routine 
- 
  ! Wrapper: Store outer type contribution cache element in file fname
  subroutine contrib_cache_outer_store(len_cache, cache, fname, r_flag, mat_acc_in)
  

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -447,7 +447,7 @@ module rsp_property_caching
          write(funit) cache(i)%indices
       
          
-         call contrib_cache_outer_put(size(cache(i)%contribs_outer), 
+         call contrib_cache_outer_put(size(cache(i)%contribs_outer), &
               cache(i)%contribs_outer, fname, funit, mat_acc_in=mat_acc)
    
    
@@ -462,16 +462,16 @@ module rsp_property_caching
  ! FIXME: Definitely ll-to-array chgs needed for this routine
  
  ! Retrieve contribution cache structure (including outer attached instances) from file fname
- subroutine contrib_cache_retrieve(len_cache, cache, fname)
+ subroutine contrib_cache_retrieve(cache, fname)
  
    implicit none
    
    logical :: termination, cache_ext
    integer :: num_entries, i, j, funit
-   integer :: len_cache, dum
+   integer :: dum
    character(*) :: fname
   
-   type(contrib_cache), dimension(len_cache) :: cache
+   type(contrib_cache), dimension(:), allocatable :: cache
 
    ! Old LL functionality: Rewrite together with store routine into array form   
    
@@ -501,8 +501,6 @@ module rsp_property_caching
    end if 
    
    allocate(cache(num_entries))
-   
-   len_cache = num_entries
    
    do i = 1, num_entries
    
@@ -699,7 +697,7 @@ module rsp_property_caching
       open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
            form='unformatted', status='replace', action='write')
            
-      write(funit) num_entries
+      write(funit) size(cache)
         
       call contrib_cache_outer_put(size(cache), cache, fname, funit, mat_acc_in=mat_acc)
         
@@ -742,7 +740,7 @@ module rsp_property_caching
    ! Traverse and store
    do i = 1, num_entries
    
-      write(funit) size(cache(i)%contribs_outer)
+      write(funit) len_cache
    
       write(funit) size(cache(i)%p_tuples)
       do j = 1, size(cache(i)%p_tuples)
@@ -877,7 +875,7 @@ module rsp_property_caching
          
          fid_fmt = '(I10.10)'
          
-         do j = 1, size(cache_next%data_mat)
+         do j = 1, size(cache(i)%data_mat)
             
             write(str_fid, fid_fmt) j + mat_acc
          
@@ -920,16 +918,16 @@ module rsp_property_caching
  ! This is the routine to call if one wants to retrieve an entire
  ! outer cache array from a file and that outer cache is "standalone", i.e.
  ! not part of an inner cache instance
- subroutine contrib_cache_outer_retrieve(len_cache, cache, fname, funit_in, mat_acc_in)
+ subroutine contrib_cache_outer_retrieve(cache, fname, funit_in, mat_acc_in)
  
    implicit none
    
    logical :: cache_ext
    integer :: funit, i, j, k, mat_acc
    integer, optional :: funit_in, mat_acc_in
-   integer :: num_entries, len_cache
+   integer :: num_entries
    character(*) :: fname
-   type(contrib_cache_outer), dimension(len_cache) :: cache
+   type(contrib_cache_outer), dimension(:), allocatable :: cache
    
    mat_acc = 0
    if (present(mat_acc_in)) then

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -479,21 +479,24 @@ module rsp_property_caching
 
    ! Old LL functionality: Rewrite together with store routine into array form   
    
-!    inquire(file=fname // '.DAT', exist=cache_ext)
-! 
-!    if (.NOT.(cache_ext)) then
-!    
-!       write(*,*) 'ERROR: The expected cache file ', trim(adjustl(fname)), ' does not exist'
-!       stop
-!    
-!    end if
-!  
-!    funit = 260
-!  
-!    open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
-!         form='unformatted', status='old', action='read')
-!    
-!    read(funit) num_entries
+   inquire(file=fname // '.DAT', exist=cache_ext)
+
+   if (.NOT.(cache_ext)) then
+   
+      write(*,*) 'ERROR: The expected cache file ', trim(adjustl(fname)), ' does not exist'
+      stop
+   
+   end if
+ 
+   funit = 260
+ 
+   open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
+        form='unformatted', status='old', action='read')
+   
+   read(funit) num_entries
+   
+   ! CONTINUE HERE: GET A NICE SYSTEM FOR ALLOCATING THE CACHES (ALWAYS PASS INTO HERE UNALLOCATED?)
+   ! OR ALWAYS DEALLOC THE INCOMING CACHE IF IT IS ALLOCATED AND THEN BUILD IT AGAIN FROM HERE?
 ! 
 !    ! Cache allocation may need own subroutine because of target/pointer issues
 !    ! Set up first element of cache
@@ -564,8 +567,6 @@ module rsp_property_caching
   
    type(contrib_cache) :: cache
   
-   ! CMNTD OUT IN LL 2 ARRAY WORK
-!    read(funit) cache%last
    read(funit) cache%p_inner%npert
    
    if (cache%p_inner%npert == 0) then

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -916,18 +916,20 @@ module rsp_property_caching
  ! FIXME: Definitely ll-to-array chgs needed for this routine 
  ! Don't know what to do about mem mgr update yet
  
- ! Wrapper 1: Get outer contribution cache instance from file fname
- ! Add condition to handle "not from inner"
- subroutine contrib_cache_outer_retrieve(cache, fname, from_inner, funit_in, mat_acc_in)
+ ! Wrapper: Get outer contribution cache instance from file fname
+ ! This is the routine to call if one wants to retrieve an entire
+ ! outer cache array from a file and that outer cache is "standalone", i.e.
+ ! not part of an inner cache instance
+ subroutine contrib_cache_outer_retrieve(len_cache, cache, fname, funit_in, mat_acc_in)
  
    implicit none
    
-   logical :: from_inner, cache_ext
+   logical :: cache_ext
    integer :: funit, i, j, k, mat_acc
    integer, optional :: funit_in, mat_acc_in
-   integer :: num_entries
+   integer :: num_entries, len_cache
    character(*) :: fname
-   type(contrib_cache_outer) :: cache
+   type(contrib_cache_outer), dimension(len_cache) :: cache
    
    mat_acc = 0
    if (present(mat_acc_in)) then


### PR DESCRIPTION
##  Description

I have updated the restarting functionality to work with the new caching framework, wherein the previous linked list functionality was changed to instead use resizable arrays. The restarting functionality, being based around writing to files and reading from files such cache structures, had to be rewritten to work with this new cache structure. Suggested reviewer @bingao or @bast .

## Motivation and Context

This update makes the restarting functionality of OpenRSP available again.

## How Has This Been Tested?

I did (non-formalized) integration testing with LSDalton built with GNU compilers: For the properties Egggf and Eggf (third and second geometric derivatives of the dipole moment, respectively), I manually stopped and resumed the calculation at various points, such as during calculation of lower-order Fock matrix contributions, during solution of response equation sets, and during calculation of expectation values. I also did multi-part stopping and resumption, where I stopped, resumed and stopped again, until finally resuming until the end. The comparison testing was done by comparing some elements of the resulting response tensor, or in the case of the testing done for Eggf, comparing by diff the entire tensor, to reference values produced without making use of restarting functionality.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Status
- [X]  Ready to go
