### PR TITLE
Memleak fix: Go through caches and dealloc matrices after use

### DIFF
--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -58,6 +58,7 @@ module rsp_general
                                   contrib_cache_outer_store, &
                                   contrib_cache_store, &
                                   contrib_cache_locate, &
+                                  contrib_cache_outer_dealloc_mat, &
                                   mat_scal_store, &
                                   mat_scal_retrieve, &
                                   rs_check, &
@@ -798,6 +799,22 @@ module rsp_general
        
     end if
     
+    call contrib_cache_outer_dealloc_mat(size(F), F)
+    call contrib_cache_outer_dealloc_mat(size(D), D)
+    call contrib_cache_outer_dealloc_mat(size(S), S)
+    
+    do i = 1, size(F_unpert_arr)
+       call QcMatDst(F_unpert_arr(i))
+    end do
+    
+    do i = 1, size(D_unpert_arr)
+       call QcMatDst(D_unpert_arr(i))
+    end do
+    
+    do i = 1, size(S_unpert_arr)
+       call QcMatDst(S_unpert_arr(i))
+    end do
+
     
     deallocate(F)
     deallocate(D)

--- a/src/ao_dens/rsp_perturbed_sdf.f90
+++ b/src/ao_dens/rsp_perturbed_sdf.f90
@@ -39,7 +39,7 @@ module rsp_perturbed_sdf
     integer, dimension(3) :: prog_info, rs_info
     integer, dimension(2) :: this_kn
     integer, dimension(sum(n_freq_cfgs), 2) :: kn_rule
-    integer :: i, j, k, m, max_order, max_npert, o_size, lof_mem_total
+    integer :: i, j, k, m, n, max_order, max_npert, o_size, lof_mem_total
     integer :: r_flag
     integer :: c_ord
     integer :: len_curr_outer, len_d, len_lof_cache
@@ -382,6 +382,16 @@ module rsp_perturbed_sdf
        call mem_decr(mem_mgr, lof_mem_total)
        
        call prog_incr(prog_info, r_flag, 2)
+       
+       do n = 1, size(lof_cache)
+    
+          if (allocated(lof_cache(n)%contribs_outer)) then
+    
+             call contrib_cache_outer_dealloc_mat(size(lof_cache(n)%contribs_outer), lof_cache(n)%contribs_outer)
+    
+          end if 
+    
+       end do
        
        deallocate(lof_cache)
        

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -28,6 +28,7 @@ module rsp_property_caching
  public contrib_cache_retrieve
  public contrib_cache_outer_store
  public contrib_cache_outer_retrieve
+ public contrib_cache_outer_dealloc_mat
  public mat_scal_store
  public mat_scal_retrieve
  public rs_check
@@ -2483,6 +2484,30 @@ end function
    end if
 
 
+ end subroutine
+ 
+ subroutine contrib_cache_outer_dealloc_mat(len_cache, cache)
+ 
+   implicit none
+ 
+   integer :: len_cache, i, j
+   type(contrib_cache_outer), dimension(len_cache) :: cache
+   
+   do i = 1, len_cache
+   
+      if (allocated(cache(i)%data_mat)) then
+      
+         do j = 1, size(cache(i)%data_mat)
+         
+            call QcMatDst(cache(i)%data_mat(j))
+         
+         end do
+      
+      end if
+   
+   end do
+ 
+ 
  end subroutine
 
 end module


### PR DESCRIPTION
## Description

I added deallocation of cache structures using matrices - tests so far indicate that this has removed memory leaks when used with LSDalton.

## Motivation and Context

Partially fixes issue 22 of LSDalton on GitLab. 

## How Has This Been Tested?

Local GNU build, I chose two of the integration tests in LSDalton and inspected the results. The results indicate that for these tests, any remaining leaks are in LSDalton. Not fully sure if all leaks in OpenRSP are plugged but coverage with these two tests were decent. At any rate this is an improvement and may be the full fix.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Questions

- [x]  Why is OpenRSP so awesome?

## Status

- [x]  Ready to go
