### PR TITLE
OpenRSP now looks for available file units before choosing one to use

### DIFF
--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -4623,7 +4623,7 @@ module rsp_general
 
     else
     
-    call get_safe_funit(unit)
+    call get_safe_funit(funit)
 
     open(unit=funit, file='rsp_tensor', status='old', action='write', &
          position='append') 

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -63,8 +63,7 @@ module rsp_general
                                   mat_scal_retrieve, &
                                   rs_check, &
                                   prog_incr, &
-                                  prog_init, &
-                                  get_safe_funit
+                                  prog_init
                                   
                                   
   
@@ -688,9 +687,7 @@ module rsp_general
        ! NOTE: This routine is placed here due to access to index/addressing routines
        ! Should be moved to API level once index/addressing routines are abstracted
        
-       funit = get_safe_funit()
-       
-       open(unit=funit, file='rsp_tensor', status='replace', action='write') 
+       open(newunit=funit, file='rsp_tensor', status='replace', action='write') 
        
        write(funit,*) 'VERSION'
        write(funit,*) '1'
@@ -4614,18 +4611,14 @@ module rsp_general
 
     end do
 
-    funit = get_safe_funit()
-    
-    open(unit=funit, file='rsp_tensor', status='old', action='write', &
+    open(newunit=funit, file='rsp_tensor', status='old', action='write', &
          position='append') 
     write(funit,*) ' '
     close(funit)
 
     else
     
-    funit = get_safe_funit()
-
-    open(unit=funit, file='rsp_tensor', status='old', action='write', &
+    open(newunit=funit, file='rsp_tensor', status='old', action='write', &
          position='append') 
     write(funit,*) real(prop(offset:offset+pdim(npert) - 1))
     close(funit)

--- a/src/ao_dens/rsp_general.f90
+++ b/src/ao_dens/rsp_general.f90
@@ -688,7 +688,7 @@ module rsp_general
        ! NOTE: This routine is placed here due to access to index/addressing routines
        ! Should be moved to API level once index/addressing routines are abstracted
        
-       call get_safe_funit(funit)
+       funit = get_safe_funit()
        
        open(unit=funit, file='rsp_tensor', status='replace', action='write') 
        
@@ -4614,7 +4614,7 @@ module rsp_general
 
     end do
 
-    call get_safe_funit(funit)
+    funit = get_safe_funit()
     
     open(unit=funit, file='rsp_tensor', status='old', action='write', &
          position='append') 
@@ -4623,7 +4623,7 @@ module rsp_general
 
     else
     
-    call get_safe_funit(funit)
+    funit = get_safe_funit()
 
     open(unit=funit, file='rsp_tensor', status='old', action='write', &
          position='append') 

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -962,7 +962,7 @@ module rsp_property_caching
    
    end if
    
-   if present(funit_in) then
+   if (present(funit_in)) then
    
       open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
            form='unformatted', status='old', action='read')

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -118,7 +118,7 @@ module rsp_property_caching
     if (u_test >= u_limit) then
     
        write(*,*) 'ERROR (OpenRSP): No available file unit for I/O found up to', u_limit
-       exit
+       call exit()
         
     end if
     

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -16,7 +16,6 @@ module rsp_property_caching
 
  implicit none
  
- public get_safe_funit
  public contrib_cache_initialize
  public contrib_cache_locate
  public contrib_cache_outer_add_element
@@ -91,41 +90,7 @@ module rsp_property_caching
  end type 
  
  contains
- 
-  function get_safe_funit()
-  
-    implicit none
-    
-    integer :: get_safe_funit
-    integer :: u_test, u_limit, u_start
-    logical :: is_occ
-    
-    u_start = 10
-    u_limit = 10000
-    
-    is_occ = .TRUE.
-    
-    u_test = u_start - 1
-    
-    do while ((is_occ .eqv. .TRUE.) .AND. (u_test <= u_limit))
-       
-       u_test = u_test + 1
-    
-       inquire(u_test, opened=is_occ)
-               
-    end do
-    
-    if (u_test >= u_limit) then
-    
-       write(*,*) 'ERROR (OpenRSP): No available file unit for I/O found up to', u_limit
-       call exit()
-        
-    end if
-    
-    get_safe_funit = u_test
-    
-  end function
-    
+     
   ! Initialize progress/restarting framework if dictated
   ! by restart flag r_flag
   subroutine prog_init(rs_info, r_flag)
@@ -142,9 +107,7 @@ module rsp_property_caching
     
        if (r_exist) then
        
-          funit = get_safe_funit()
-       
-          open(unit=funit, file='OPENRSP_RESTART', action='read') 
+          open(newunit=funit, file='OPENRSP_RESTART', action='read') 
           read(funit,*) rs_info(1)
           read(funit,*) rs_info(2)
           read(funit,*) rs_info(3)
@@ -233,9 +196,7 @@ module rsp_property_caching
     
     if (r_flag == 3) then
     
-       funit = get_safe_funit()
-    
-       open(unit=funit, file='OPENRSP_RESTART', status='replace', action='write') 
+       open(newunit=funit, file='OPENRSP_RESTART', status='replace', action='write') 
        write(funit,*) prog_info(1)
        write(funit,*) prog_info(2)
        write(funit,*) prog_info(3)
@@ -264,11 +225,9 @@ module rsp_property_caching
     
    elseif (r_flag == 3) then
  
-      funit = get_safe_funit()
-   
       if (present(scal)) then
  
-         open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
+         open(newunit=funit, file=trim(adjustl(fname)) // '.DAT', &
               form='unformatted', status='replace', action='write')
    
          write(funit) array_size
@@ -319,11 +278,9 @@ module rsp_property_caching
    complex(8), dimension(array_size), optional :: scal
    type(QcMat), dimension(array_size), optional :: mat
  
-   funit = get_safe_funit()
- 
    if (present(scal)) then
  
-      open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
+      open(newunit=funit, file=trim(adjustl(fname)) // '.DAT', &
         form='unformatted', status='old', action='read')
    
       read(funit) array_size
@@ -372,9 +329,7 @@ module rsp_property_caching
 
       mat_acc = 0
  
-      funit = get_safe_funit()
- 
-      open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
+      open(newunit=funit, file=trim(adjustl(fname)) // '.DAT', &
         form='unformatted', status='replace', action='write')
    
       ! Find how many unperturbed elements: They should be skippable when writing
@@ -539,9 +494,7 @@ module rsp_property_caching
    
    end if
  
-   funit = get_safe_funit()
- 
-   open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
+   open(newunit=funit, file=trim(adjustl(fname)) // '.DAT', &
         form='unformatted', status='old', action='read')
    
    read(funit) num_entries
@@ -754,9 +707,7 @@ module rsp_property_caching
          mat_acc = mat_acc_in
       end if   
    
-      funit = get_safe_funit()
- 
-      open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
+      open(newunit=funit, file=trim(adjustl(fname)) // '.DAT', &
            form='unformatted', status='replace', action='write')
            
       write(funit) size(cache)
@@ -997,7 +948,6 @@ module rsp_property_caching
    end if
    
 
-   funit = get_safe_funit()
    if (present(funit_in)) then
       funit = funit_in
    end if
@@ -1011,9 +961,18 @@ module rsp_property_caching
       stop
    
    end if
-      
-   open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
-        form='unformatted', status='old', action='read')
+   
+   if present(funit_in) then
+   
+      open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
+           form='unformatted', status='old', action='read')
+           
+   else
+
+      open(newunit=funit, file=trim(adjustl(fname)) // '.DAT', &
+           form='unformatted', status='old', action='read')
+   
+   end if
   
    read(funit) num_entries
    

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -92,11 +92,11 @@ module rsp_property_caching
  
  contains
  
-  subroutine get_safe_funit(u)
+  function get_safe_funit()
   
     implicit none
     
-    integer, intent(inout) :: u
+    integer :: get_safe_funit
     integer :: u_test, u_limit, u_start
     logical :: is_occ
     
@@ -122,9 +122,9 @@ module rsp_property_caching
         
     end if
     
-    u = u_test
+    get_safe_funit = u_test
     
-  end subroutine
+  end function
     
   ! Initialize progress/restarting framework if dictated
   ! by restart flag r_flag
@@ -142,7 +142,7 @@ module rsp_property_caching
     
        if (r_exist) then
        
-          call get_safe_funit(funit)
+          funit = get_safe_funit()
        
           open(unit=funit, file='OPENRSP_RESTART', action='read') 
           read(funit,*) rs_info(1)
@@ -233,7 +233,7 @@ module rsp_property_caching
     
     if (r_flag == 3) then
     
-       call get_safe_funit(funit)
+       funit = get_safe_funit()
     
        open(unit=funit, file='OPENRSP_RESTART', status='replace', action='write') 
        write(funit,*) prog_info(1)
@@ -264,7 +264,7 @@ module rsp_property_caching
     
    elseif (r_flag == 3) then
  
-      call get_safe_funit(funit)
+      funit = get_safe_funit()
    
       if (present(scal)) then
  
@@ -319,7 +319,7 @@ module rsp_property_caching
    complex(8), dimension(array_size), optional :: scal
    type(QcMat), dimension(array_size), optional :: mat
  
-   call get_safe_funit(funit)
+   funit = get_safe_funit()
  
    if (present(scal)) then
  
@@ -372,7 +372,7 @@ module rsp_property_caching
 
       mat_acc = 0
  
-      call get_safe_funit(funit)
+      funit = get_safe_funit()
  
       open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
         form='unformatted', status='replace', action='write')
@@ -539,7 +539,7 @@ module rsp_property_caching
    
    end if
  
-   call get_safe_funit(funit)
+   funit = get_safe_funit()
  
    open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
         form='unformatted', status='old', action='read')
@@ -754,7 +754,7 @@ module rsp_property_caching
          mat_acc = mat_acc_in
       end if   
    
-      call get_safe_funit(funit)
+      funit = get_safe_funit()
  
       open(unit=funit, file=trim(adjustl(fname)) // '.DAT', &
            form='unformatted', status='replace', action='write')
@@ -997,7 +997,7 @@ module rsp_property_caching
    end if
    
 
-   call get_safe_funit(funit)
+   funit = get_safe_funit()
    if (present(funit_in)) then
       funit = funit_in
    end if

--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -107,7 +107,7 @@ module rsp_property_caching
     
     u_test = u_start - 1
     
-    do while ((is_occ .equiv. .TRUE.) .AND. (u_test <= u_limit))
+    do while ((is_occ .eqv. .TRUE.) .AND. (u_test <= u_limit))
        
        u_test = u_test + 1
     


### PR DESCRIPTION
##  Description

I introduced a subroutine to browse through I/O unit numbers and INQUIRE if they are in use. If they are, then OpenRSP keeps looking (up to a limit) until it finds one which is available. This is now used in all OpenRSP functionality dealing with file I/O. Please dr @bast for to look at this

## Motivation and Context
Avoid I/O unit conflicts between OpenRSP and connected modules.

## How Has This Been Tested?
Integration tests with LSDalton on local GNU build. All but one test passed and that one failure is probably to do with other existing problems.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Status
- [x]  Ready to go
