### PR TITLE
Initializing num outer cache elements of inner cache

### DIFF
--- a/src/ao_dens/rsp_property_caching.f90
+++ b/src/ao_dens/rsp_property_caching.f90
@@ -1312,6 +1312,8 @@ module rsp_property_caching
    current_element(1)%p_inner%freq = (/0.0/)
    
   call contrib_cache_outer_allocate(current_element(1)%contribs_outer)
+  
+  current_element(1)%num_outer = 1
    
  end subroutine
 


### PR DESCRIPTION
## Description

I now initialize a "regular" cache element to have one "outer" cache element associated to it (not in the sense of pointer association). This number was sometimes previously uninitialized. This fixes an allocation bug where the program would try to allocate a junk number of elements.

## How Has This Been Tested?

Integration tests with LSDalton, two local runs gave no errors, CI pipeline on LSDalton side also clean. Possibly may affect restarting functionality, plan to test that later.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Status
- [x ]  Ready to go
