### PR TITLE
add .zenodo.json so that I don't have to enter these manually on Zenodo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,29 @@
+{
+    "creators": [
+        {
+            "name": "Bast, Radovan"
+        },
+        {
+            "name": "Friese, Daniel H."
+        },
+        {
+            "name": "Gao, Bin"
+        },
+        {
+            "name": "Jonsson, Dan J."
+        },
+        {
+            "name": "Ringholm, Magnus"
+        },
+        {
+            "name": "Reine, Simen S."
+        },
+        {
+            "name": "Ruud, Kenneth"
+        }
+    ],
+    "license": {
+        "id": "LGPL-2.1"
+    },
+    "title": "OpenRSP: open-ended response theory"
+}


### PR DESCRIPTION
This file will populate the form on Zenodo so that I don't have to re-enter this for every release.